### PR TITLE
Skip examples if `DIGITALOCEAN_TOKEN` is not set

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -23,15 +23,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var base = integration.ProgramTestOptions{
-	ExpectRefreshChanges: true,
-	// Note: no Config! This package should be usable without any config.
-}
-
 func TestDomain(t *testing.T) {
+	token := os.Getenv("DIGITALOCEAN_TOKEN")
+	if token == "" {
+		t.Skipf("Skipping test due to missing DIGITALOCEAN_TOKEN environment variable")
+	}
+
 	cwd, err := os.Getwd()
 	if !assert.NoError(t, err) {
 		t.FailNow()
+	}
+
+	var base = integration.ProgramTestOptions{
+		ExpectRefreshChanges: true,
+		Config: map[string]string{
+			"digitalocean:token": token,
+		},
 	}
 
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/sdk/nodejs/getImage.ts
+++ b/sdk/nodejs/getImage.ts
@@ -35,7 +35,7 @@ import * as utilities from "./utilities";
  *     name: "example-1.0.0",
  * }));
  * const example1Droplet = new digitalocean.Droplet("example1", {
- *     image: example1Image.apply(example1Image => example1Image.image),
+ *     image: example1Image.image,
  *     region: "nyc2",
  *     size: "s-1vcpu-1gb",
  * });

--- a/sdk/nodejs/getVolume.ts
+++ b/sdk/nodejs/getVolume.ts
@@ -43,7 +43,7 @@ import * as utilities from "./utilities";
  * });
  * const foobar = new digitalocean.VolumeAttachment("foobar", {
  *     dropletId: exampleDroplet.id,
- *     volumeId: exampleVolume.apply(exampleVolume => exampleVolume.id),
+ *     volumeId: exampleVolume.id,
  * });
  * ```
  */

--- a/sdk/nodejs/getVolumeSnapshot.ts
+++ b/sdk/nodejs/getVolumeSnapshot.ts
@@ -38,7 +38,7 @@ import * as utilities from "./utilities";
  * const foobar = new digitalocean.Volume("foobar", {
  *     region: "nyc3",
  *     size: 100,
- *     snapshotId: snapshot.apply(snapshot => snapshot.id),
+ *     snapshotId: snapshot.id,
  * });
  * ```
  */

--- a/sdk/nodejs/volume.ts
+++ b/sdk/nodejs/volume.ts
@@ -41,8 +41,8 @@ import * as utilities from "./utilities";
  * }));
  * const foobarVolume = new digitalocean.Volume("foobar", {
  *     region: "lon1",
- *     size: foobarVolumeSnapshot.apply(foobarVolumeSnapshot => foobarVolumeSnapshot.minDiskSize),
- *     snapshotId: foobarVolumeSnapshot.apply(foobarVolumeSnapshot => foobarVolumeSnapshot.id),
+ *     size: foobarVolumeSnapshot.minDiskSize,
+ *     snapshotId: foobarVolumeSnapshot.id,
  * });
  * ```
  */


### PR DESCRIPTION
This PR sets the DigitalOcean token directly as config, but skips the tests if it is not set (e.g. local runs).