### PR TITLE
Fix API docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ been added to make development easier and to help avoid common mistakes, and to 
 ## Reference
 
 For detailed reference documentation, please visit [the API docs](
-https://pulumi.io/reference/pkg/nodejs/@pulumi/digitalocean/index.html).
+https://pulumi.io/reference/pkg/nodejs/pulumi/digitalocean/).
 
 ## Updating this provider
 

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -62,7 +62,7 @@ Reference
 ---------
 
 For detailed reference documentation, please visit `the API
-docs <https://pulumi.io/reference/pkg/nodejs/@pulumi/digitalocean/index.html>`__.
+docs <https://pulumi.io/reference/pkg/nodejs/pulumi/digitalocean/>`__.
 
 Updating this provider
 ----------------------


### PR DESCRIPTION
Once https://github.com/pulumi/docs/pull/1094 is merged and deployed to production, this can be merged.

Fixes #5