### PR TITLE
Addition of a mixin for DigitalOcean regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 * Add TypeScript type guards for each resource class
+* Add a Region mixin for Region typing
 
 ---
 

--- a/examples/droplet/index.ts
+++ b/examples/droplet/index.ts
@@ -16,7 +16,7 @@ import * as digitalocean from "@pulumi/digitalocean";
 
  const web = new digitalocean.Droplet("web", {
      image: "ubuntu-18-04-x64",
-     region: "nyc1",
+     region: digitalocean.NYC1Region,
      size: "s-1vcpu-1gb",
  });
 

--- a/examples/floatingip/index.ts
+++ b/examples/floatingip/index.ts
@@ -15,7 +15,7 @@
 import * as digitalocean from "@pulumi/digitalocean";
 
  const ip = new digitalocean.FloatingIp("ip", {
-     region: "nyc1",
+     region: digitalocean.NYC1Region,
  });
 
  export let ipAddress = ip.ipAddress;

--- a/examples/loadbalancer/index.ts
+++ b/examples/loadbalancer/index.ts
@@ -18,7 +18,7 @@ const foobar = new digitalocean.Tag("foobar", {});
 
 const web = new digitalocean.Droplet("web", {
     image: "ubuntu-18-04-x64",
-    region: "nyc1",
+    region: digitalocean.NYC1Region,
     size: "s-1vcpu-1gb",
     tags: [foobar.id],
 });
@@ -35,7 +35,7 @@ const lb = new digitalocean.LoadBalancer("public", {
         port: 22,
         protocol: "tcp",
     },
-    region: "nyc1",
+    region: digitalocean.NYC1Region,
 });
 
 export let status = lb.status;

--- a/resources.go
+++ b/resources.go
@@ -92,26 +92,66 @@ func Provider() tfbridge.ProviderInfo {
 			},
 		},
 		Resources: map[string]*tfbridge.ResourceInfo{
-			"digitalocean_cdn":                    {Tok: digitalOceanResource(digitalOceanMod, "Cdn")},
-			"digitalocean_certificate":            {Tok: digitalOceanResource(digitalOceanMod, "Certificate")},
-			"digitalocean_database_cluster":       {Tok: digitalOceanResource(digitalOceanMod, "DatabaseCluster")},
-			"digitalocean_domain":                 {Tok: digitalOceanResource(digitalOceanMod, "Domain")},
-			"digitalocean_droplet":                {Tok: digitalOceanResource(digitalOceanMod, "Droplet")},
+			"digitalocean_cdn":         {Tok: digitalOceanResource(digitalOceanMod, "Cdn")},
+			"digitalocean_certificate": {Tok: digitalOceanResource(digitalOceanMod, "Certificate")},
+			"digitalocean_database_cluster": {
+				Tok: digitalOceanResource(digitalOceanMod, "DatabaseCluster"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"region": {
+						Type: digitalOceanType(digitalOceanMod, "Region"),
+					},
+				},
+			},
+			"digitalocean_domain": {Tok: digitalOceanResource(digitalOceanMod, "Domain")},
+			"digitalocean_droplet": {
+				Tok: digitalOceanResource(digitalOceanMod, "Droplet"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"region": {
+						Type: digitalOceanType(digitalOceanMod, "Region"),
+					},
+				},
+			},
 			"digitalocean_droplet_snapshot":       {Tok: digitalOceanResource(digitalOceanMod, "DropletSnapshot")},
 			"digitalocean_firewall":               {Tok: digitalOceanResource(digitalOceanMod, "Firewall")},
 			"digitalocean_floating_ip":            {Tok: digitalOceanResource(digitalOceanMod, "FloatingIp")},
 			"digitalocean_floating_ip_assignment": {Tok: digitalOceanResource(digitalOceanMod, "FloatingIpAssignment")},
-			"digitalocean_kubernetes_cluster":     {Tok: digitalOceanResource(digitalOceanMod, "KubernetesCluster")},
-			"digitalocean_kubernetes_node_pool":   {Tok: digitalOceanResource(digitalOceanMod, "KubernetesNodePool")},
+			"digitalocean_kubernetes_cluster": {
+				Tok: digitalOceanResource(digitalOceanMod, "KubernetesCluster"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"region": {
+						Type: digitalOceanType(digitalOceanMod, "Region"),
+					},
+				},
+			},
+			"digitalocean_kubernetes_node_pool": {Tok: digitalOceanResource(digitalOceanMod, "KubernetesNodePool")},
 			"digitalocean_loadbalancer": {
 				Tok: digitalOceanResource(digitalOceanMod, "LoadBalancer"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"region": {
+						Type: digitalOceanType(digitalOceanMod, "Region"),
+					},
+				},
 			},
-			"digitalocean_project":           {Tok: digitalOceanResource(digitalOceanMod, "Project")},
-			"digitalocean_record":            {Tok: digitalOceanResource(digitalOceanMod, "DnsRecord")},
-			"digitalocean_ssh_key":           {Tok: digitalOceanResource(digitalOceanMod, "SshKey")},
-			"digitalocean_spaces_bucket":     {Tok: digitalOceanResource(digitalOceanMod, "SpacesBucket")},
-			"digitalocean_tag":               {Tok: digitalOceanResource(digitalOceanMod, "Tag")},
-			"digitalocean_volume":            {Tok: digitalOceanResource(digitalOceanMod, "Volume")},
+			"digitalocean_project": {Tok: digitalOceanResource(digitalOceanMod, "Project")},
+			"digitalocean_record":  {Tok: digitalOceanResource(digitalOceanMod, "DnsRecord")},
+			"digitalocean_ssh_key": {Tok: digitalOceanResource(digitalOceanMod, "SshKey")},
+			"digitalocean_spaces_bucket": {
+				Tok: digitalOceanResource(digitalOceanMod, "SpacesBucket"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"region": {
+						Type: digitalOceanType(digitalOceanMod, "Region"),
+					},
+				},
+			},
+			"digitalocean_tag": {Tok: digitalOceanResource(digitalOceanMod, "Tag")},
+			"digitalocean_volume": {
+				Tok: digitalOceanResource(digitalOceanMod, "Volume"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"region": {
+						Type: digitalOceanType(digitalOceanMod, "Region"),
+					},
+				},
+			},
 			"digitalocean_volume_attachment": {Tok: digitalOceanResource(digitalOceanMod, "VolumeAttachment")},
 			"digitalocean_volume_snapshot":   {Tok: digitalOceanResource(digitalOceanMod, "VolumeSnapshot")},
 		},
@@ -141,7 +181,9 @@ func Provider() tfbridge.ProviderInfo {
 				"@types/node": "^8.0.25", // so we can access strongly typed node definitions.
 			},
 			Overlay: &tfbridge.OverlayInfo{
-				Files:   []string{},
+				DestFiles: []string{
+					"region.ts", // Region union type and constants
+				},
 				Modules: map[string]*tfbridge.OverlayInfo{},
 			},
 		},

--- a/sdk/nodejs/databaseCluster.ts
+++ b/sdk/nodejs/databaseCluster.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+import {Region} from "./index";
+
 /**
  * Provides a DigitalOcean database cluster resource.
  * 
@@ -85,7 +87,7 @@ export class DatabaseCluster extends pulumi.CustomResource {
     /**
      * DigitalOcean region where the cluster will reside.
      */
-    public readonly region!: pulumi.Output<string>;
+    public readonly region!: pulumi.Output<Region>;
     /**
      * Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
      */
@@ -202,7 +204,7 @@ export interface DatabaseClusterState {
     /**
      * DigitalOcean region where the cluster will reside.
      */
-    readonly region?: pulumi.Input<string>;
+    readonly region?: pulumi.Input<Region>;
     /**
      * Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
      */
@@ -244,7 +246,7 @@ export interface DatabaseClusterArgs {
     /**
      * DigitalOcean region where the cluster will reside.
      */
-    readonly region: pulumi.Input<string>;
+    readonly region: pulumi.Input<Region>;
     /**
      * Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
      */

--- a/sdk/nodejs/droplet.ts
+++ b/sdk/nodejs/droplet.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+import {Region} from "./index";
+
 /**
  * Provides a DigitalOcean Droplet resource. This can be used to create,
  * modify, and delete Droplets. Droplets also support
@@ -110,7 +112,7 @@ export class Droplet extends pulumi.CustomResource {
     /**
      * The region to start in.
      */
-    public readonly region!: pulumi.Output<string>;
+    public readonly region!: pulumi.Output<Region>;
     /**
      * Boolean controlling whether to increase the disk
      * size when resizing a Droplet. It defaults to `true`. When set to `false`,
@@ -297,7 +299,7 @@ export interface DropletState {
     /**
      * The region to start in.
      */
-    readonly region?: pulumi.Input<string>;
+    readonly region?: pulumi.Input<Region>;
     /**
      * Boolean controlling whether to increase the disk
      * size when resizing a Droplet. It defaults to `true`. When set to `false`,
@@ -377,7 +379,7 @@ export interface DropletArgs {
     /**
      * The region to start in.
      */
-    readonly region: pulumi.Input<string>;
+    readonly region: pulumi.Input<Region>;
     /**
      * Boolean controlling whether to increase the disk
      * size when resizing a Droplet. It defaults to `true`. When set to `false`,

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -30,6 +30,7 @@ export * from "./kubernetesNodePool";
 export * from "./loadBalancer";
 export * from "./project";
 export * from "./provider";
+export * from "./region";
 export * from "./spacesBucket";
 export * from "./sshKey";
 export * from "./tag";

--- a/sdk/nodejs/kubernetesCluster.ts
+++ b/sdk/nodejs/kubernetesCluster.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+import {Region} from "./index";
+
 /**
  * > **NOTE:** DigitalOcean Kubernetes is currently in [Limited Availability](https://www.digitalocean.com/docs/platform/product-lifecycle/). In order to access its API, you must first enable Kubernetes on your account by opting-in via the [cloud control panel](https://cloud.digitalocean.com/kubernetes/clusters). While the Kubernetes Cluster functionality is currently in limited availability the structure of this resource may change over time. Please share any feedback you may have by [opening an issue on GitHub](https://github.com/terraform-providers/terraform-provider-digitalocean/issues).
  * 
@@ -68,7 +70,7 @@ export class KubernetesCluster extends pulumi.CustomResource {
     /**
      * The slug identifier for the region where the Kubernetes cluster will be created.
      */
-    public readonly region!: pulumi.Output<string>;
+    public readonly region!: pulumi.Output<Region>;
     /**
      * The range of assignable IP addresses for services running in the Kubernetes cluster.
      */
@@ -186,7 +188,7 @@ export interface KubernetesClusterState {
     /**
      * The slug identifier for the region where the Kubernetes cluster will be created.
      */
-    readonly region?: pulumi.Input<string>;
+    readonly region?: pulumi.Input<Region>;
     /**
      * The range of assignable IP addresses for services running in the Kubernetes cluster.
      */
@@ -234,7 +236,7 @@ export interface KubernetesClusterArgs {
     /**
      * The slug identifier for the region where the Kubernetes cluster will be created.
      */
-    readonly region: pulumi.Input<string>;
+    readonly region: pulumi.Input<Region>;
     /**
      * A list of tag names to be applied to the Kubernetes cluster.
      */

--- a/sdk/nodejs/loadBalancer.ts
+++ b/sdk/nodejs/loadBalancer.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+import {Region} from "./index";
+
 /**
  * Provides a DigitalOcean Load Balancer resource. This can be used to create,
  * modify, and delete Load Balancers.
@@ -143,7 +145,7 @@ export class LoadBalancer extends pulumi.CustomResource {
     /**
      * The region to start in
      */
-    public readonly region!: pulumi.Output<string>;
+    public readonly region!: pulumi.Output<Region>;
     public /*out*/ readonly status!: pulumi.Output<string>;
     /**
      * A `sticky_sessions` block to be assigned to the
@@ -254,7 +256,7 @@ export interface LoadBalancerState {
     /**
      * The region to start in
      */
-    readonly region?: pulumi.Input<string>;
+    readonly region?: pulumi.Input<Region>;
     readonly status?: pulumi.Input<string>;
     /**
      * A `sticky_sessions` block to be assigned to the
@@ -314,7 +316,7 @@ export interface LoadBalancerArgs {
     /**
      * The region to start in
      */
-    readonly region: pulumi.Input<string>;
+    readonly region: pulumi.Input<Region>;
     /**
      * A `sticky_sessions` block to be assigned to the
      * Load Balancer. The `sticky_sessions` block is documented below. Only 1 sticky_sessions block is allowed.

--- a/sdk/nodejs/region.ts
+++ b/sdk/nodejs/region.ts
@@ -1,0 +1,44 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export let NYC1Region: Region = "nyc1";
+export let NYC2Region: Region = "nyc2";
+export let NYC3Region: Region = "nyc3";
+export let SGP1Region: Region = "sgp1"
+export let LON1Region: Region = "lon1"
+export let AMS2Region: Region = "ams2"
+export let AMS3Region: Region = "ams3"
+export let FRA1Region: Region = "fra1"
+export let TOR1Region: Region = "tor1"
+export let SFO1Region: Region = "sfo1"
+export let SFO2Region: Region = "sfo2"
+export let BLR1Region: Region = "blr1"
+
+/**
+ * A Region represents any valid DigitalOcean region that may be targeted with deployments.
+ */
+export type Region =
+    "nyc1" |
+    "nyc2" |
+    "nyc3" |
+    "sgp1" |
+    "lon1" |
+    "ams2" |
+    "ams3" |
+    "fra1" |
+    "tor1" |
+    "sfo1" |
+    "sfo2" |
+    "blr1" ;
+

--- a/sdk/nodejs/spacesBucket.ts
+++ b/sdk/nodejs/spacesBucket.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+import {Region} from "./index";
+
 /**
  * Provides a bucket resource for Spaces, DigitalOcean's object storage product.
  * 
@@ -86,7 +88,7 @@ export class SpacesBucket extends pulumi.CustomResource {
     /**
      * The region where the bucket resides (Defaults to `nyc3`)
      */
-    public readonly region!: pulumi.Output<string | undefined>;
+    public readonly region!: pulumi.Output<Region | undefined>;
     /**
      * The uniform resource name for the bucket
      */
@@ -146,7 +148,7 @@ export interface SpacesBucketState {
     /**
      * The region where the bucket resides (Defaults to `nyc3`)
      */
-    readonly region?: pulumi.Input<string>;
+    readonly region?: pulumi.Input<Region>;
     /**
      * The uniform resource name for the bucket
      */
@@ -172,5 +174,5 @@ export interface SpacesBucketArgs {
     /**
      * The region where the bucket resides (Defaults to `nyc3`)
      */
-    readonly region?: pulumi.Input<string>;
+    readonly region?: pulumi.Input<Region>;
 }

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -44,6 +44,7 @@
         "loadBalancer.ts",
         "project.ts",
         "provider.ts",
+        "region.ts",
         "spacesBucket.ts",
         "sshKey.ts",
         "tag.ts",

--- a/sdk/nodejs/volume.ts
+++ b/sdk/nodejs/volume.ts
@@ -4,6 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
+import {Region} from "./index";
+
 /**
  * Provides a DigitalOcean Block Storage volume which can be attached to a Droplet in order to provide expanded storage.
  * 
@@ -104,7 +106,7 @@ export class Volume extends pulumi.CustomResource {
     /**
      * The region that the block storage volume will be created in.
      */
-    public readonly region!: pulumi.Output<string>;
+    public readonly region!: pulumi.Output<Region>;
     /**
      * The size of the block storage volume in GiB. If updated, can only be expanded.
      */
@@ -200,7 +202,7 @@ export interface VolumeState {
     /**
      * The region that the block storage volume will be created in.
      */
-    readonly region?: pulumi.Input<string>;
+    readonly region?: pulumi.Input<Region>;
     /**
      * The size of the block storage volume in GiB. If updated, can only be expanded.
      */
@@ -242,7 +244,7 @@ export interface VolumeArgs {
     /**
      * The region that the block storage volume will be created in.
      */
-    readonly region: pulumi.Input<string>;
+    readonly region: pulumi.Input<Region>;
     /**
      * The size of the block storage volume in GiB. If updated, can only be expanded.
      */


### PR DESCRIPTION
This now allows us to do the following:

```
import * as digitalocean from "@pulumi/digitalocean";

 const web = new digitalocean.Droplet("web", {
     image: "ubuntu-18-04-x64",
     region: digitalocean.NYC1Region,
     size: "s-1vcpu-1gb",
 });
```