### PR TITLE
Addition of more mixins for simple type additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (Unreleased)
 * Add TypeScript type guards for each resource class
 * Add a Region mixin for Region typing
+* Add a DatabaseSlug mixin for Database Cluster size types
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 * Add TypeScript type guards for each resource class
 * Add a Region mixin for Region typing
 * Add a DatabaseSlug mixin for Database Cluster size types
+* Add a DropletSlug mixin for Droplet size types
 
 ---
 

--- a/examples/databaseCluster/.gitignore
+++ b/examples/databaseCluster/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/databaseCluster/Pulumi.yaml
+++ b/examples/databaseCluster/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: database-cluster-digitalocean
+description: A simple database cluster on DigitalOcean.
+runtime: nodejs

--- a/examples/databaseCluster/index.ts
+++ b/examples/databaseCluster/index.ts
@@ -1,0 +1,25 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as digitalocean from "@pulumi/digitalocean";
+
+const example = new digitalocean.DatabaseCluster("example", {
+    engine: "pg",
+    nodeCount: 1,
+    region: digitalocean.NYC1Region,
+    size: digitalocean.Database1VPCU1GB,
+    version: "11",
+});
+
+export let name = example.name;

--- a/examples/databaseCluster/package.json
+++ b/examples/databaseCluster/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "minimal",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "main": "bin/index.js",
+  "typings": "bin/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "dev"
+  },
+  "devDependencies": {
+    "typescript": "^3.0.3"
+  },
+  "peerDependencies": {
+    "@pulumi/digitalocean": "latest"
+  }
+}

--- a/examples/databaseCluster/tsconfig.json
+++ b/examples/databaseCluster/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "outDir": "bin",
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "stripInternal": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "strictNullChecks": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/examples/droplet/index.ts
+++ b/examples/droplet/index.ts
@@ -17,7 +17,7 @@ import * as digitalocean from "@pulumi/digitalocean";
  const web = new digitalocean.Droplet("web", {
      image: "ubuntu-18-04-x64",
      region: digitalocean.NYC1Region,
-     size: "s-1vcpu-1gb",
+     size: digitalocean.DropletS1VPCU1GB,
  });
 
  export let ipAddress = web.ipv4Address;

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -48,6 +48,7 @@ func TestDomain(t *testing.T) {
 	})
 
 	tests := []integration.ProgramTestOptions{
+		baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "databaseCluster")}),
 		baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "domain")}),
 		baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "droplet")}),
 		baseJS.With(integration.ProgramTestOptions{Dir: path.Join(cwd, "floatingip")}),

--- a/resources.go
+++ b/resources.go
@@ -100,6 +100,9 @@ func Provider() tfbridge.ProviderInfo {
 					"region": {
 						Type: digitalOceanType(digitalOceanMod, "Region"),
 					},
+					"size": {
+						Type: digitalOceanType(digitalOceanMod, "DatabaseSlug"),
+					},
 				},
 			},
 			"digitalocean_domain": {Tok: digitalOceanResource(digitalOceanMod, "Domain")},
@@ -182,6 +185,7 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			Overlay: &tfbridge.OverlayInfo{
 				DestFiles: []string{
+					"databaseSlug.ts",
 					"region.ts", // Region union type and constants
 				},
 				Modules: map[string]*tfbridge.OverlayInfo{},

--- a/resources.go
+++ b/resources.go
@@ -112,6 +112,9 @@ func Provider() tfbridge.ProviderInfo {
 					"region": {
 						Type: digitalOceanType(digitalOceanMod, "Region"),
 					},
+					"size": {
+						Type: digitalOceanType(digitalOceanMod, "DropletSlug"),
+					},
 				},
 			},
 			"digitalocean_droplet_snapshot":       {Tok: digitalOceanResource(digitalOceanMod, "DropletSnapshot")},
@@ -186,6 +189,7 @@ func Provider() tfbridge.ProviderInfo {
 			Overlay: &tfbridge.OverlayInfo{
 				DestFiles: []string{
 					"databaseSlug.ts",
+					"dropletSlug.ts",
 					"region.ts", // Region union type and constants
 				},
 				Modules: map[string]*tfbridge.OverlayInfo{},

--- a/sdk/nodejs/databaseCluster.ts
+++ b/sdk/nodejs/databaseCluster.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
-import {Region} from "./index";
+import {DatabaseSlug, Region} from "./index";
 
 /**
  * Provides a DigitalOcean database cluster resource.
@@ -91,7 +91,7 @@ export class DatabaseCluster extends pulumi.CustomResource {
     /**
      * Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
      */
-    public readonly size!: pulumi.Output<string>;
+    public readonly size!: pulumi.Output<DatabaseSlug>;
     /**
      * The full URI for connecting to the database cluster.
      */
@@ -208,7 +208,7 @@ export interface DatabaseClusterState {
     /**
      * Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
      */
-    readonly size?: pulumi.Input<string>;
+    readonly size?: pulumi.Input<DatabaseSlug>;
     /**
      * The full URI for connecting to the database cluster.
      */
@@ -250,7 +250,7 @@ export interface DatabaseClusterArgs {
     /**
      * Database droplet size associated with the cluster (ex. `db-s-1vcpu-1gb`).
      */
-    readonly size: pulumi.Input<string>;
+    readonly size: pulumi.Input<DatabaseSlug>;
     /**
      * Engine version used by the cluster (ex. `11` for PostgreSQL 11).
      */

--- a/sdk/nodejs/databaseSlug.ts
+++ b/sdk/nodejs/databaseSlug.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export let Database1VPCU1GB:   DatabaseSlug = "db-s-1vcpu-1gb";
+export let Database1VPCU2GB:   DatabaseSlug = "db-s-1vcpu-2gb";
+export let Database2VPCU4GB:   DatabaseSlug = "db-s-2vcpu-4gb";
+export let Database4VPCU8GB:   DatabaseSlug = "db-s-4vcpu-8gb";
+export let Database6VPCU16GB:  DatabaseSlug = "db-s-6vcpu-16gb";
+export let Database8VPCU32GB:  DatabaseSlug = "db-s-8vcpu-32gb";
+export let Database16VPCU64GB: DatabaseSlug = "db-s-16vcpu-64gb";
+
+/**
+ * A DatabaseSlug represents any valid DigitalOcean database slug size that may be targeted with database clusters.
+ */
+export type DatabaseSlug =
+    "db-s-1vcpu-1gb"   |
+    "db-s-1vcpu-2gb"   |
+    "db-s-2vcpu-4gb"   |
+    "db-s-4vcpu-8gb"   |
+    "db-s-6vcpu-16gb"  |
+    "db-s-8vcpu-32gb"  |
+    "db-s-16vcpu-64gb" ;
+

--- a/sdk/nodejs/droplet.ts
+++ b/sdk/nodejs/droplet.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
-import {Region} from "./index";
+import {DropletSlug, Region} from "./index";
 
 /**
  * Provides a DigitalOcean Droplet resource. This can be used to create,
@@ -123,7 +123,7 @@ export class Droplet extends pulumi.CustomResource {
     /**
      * The unique slug that indentifies the type of Droplet. You can find a list of available slugs on [DigitalOcean API documentation](https://developers.digitalocean.com/documentation/v2/#list-all-sizes).
      */
-    public readonly size!: pulumi.Output<string>;
+    public readonly size!: pulumi.Output<DropletSlug>;
     /**
      * A list of SSH IDs or fingerprints to enable in
      * the format `[12345, 123456]`. To retrieve this info, use a tool such
@@ -310,7 +310,7 @@ export interface DropletState {
     /**
      * The unique slug that indentifies the type of Droplet. You can find a list of available slugs on [DigitalOcean API documentation](https://developers.digitalocean.com/documentation/v2/#list-all-sizes).
      */
-    readonly size?: pulumi.Input<string>;
+    readonly size?: pulumi.Input<DropletSlug>;
     /**
      * A list of SSH IDs or fingerprints to enable in
      * the format `[12345, 123456]`. To retrieve this info, use a tool such
@@ -390,7 +390,7 @@ export interface DropletArgs {
     /**
      * The unique slug that indentifies the type of Droplet. You can find a list of available slugs on [DigitalOcean API documentation](https://developers.digitalocean.com/documentation/v2/#list-all-sizes).
      */
-    readonly size: pulumi.Input<string>;
+    readonly size: pulumi.Input<DropletSlug>;
     /**
      * A list of SSH IDs or fingerprints to enable in
      * the format `[12345, 123456]`. To retrieve this info, use a tool such

--- a/sdk/nodejs/dropletSlug.ts
+++ b/sdk/nodejs/dropletSlug.ts
@@ -1,0 +1,99 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export let Droplet512mb:         DropletSlug = "512mb";
+export let Droplet1GB:           DropletSlug = "1gb";
+export let Droplet2GB:           DropletSlug = "2gb";
+export let Droplet4GB:           DropletSlug = "4gb";
+export let Droplet8GB:           DropletSlug = "8gb";
+export let Droplet16GB:          DropletSlug = "16gb";
+export let Droplet32GB:          DropletSlug = "32gb";
+export let Droplet48GB:          DropletSlug = "48gb";
+export let Droplet64GB:          DropletSlug = "64gb";
+export let DropletC2:            DropletSlug = "c-2";
+export let DropletC4:            DropletSlug = "c-4";
+export let DropletC8:            DropletSlug = "c-8";
+export let DropletC16:           DropletSlug = "c-16";
+export let DropletC32:           DropletSlug = "c-32";
+export let DropletS1VPCU1GB:     DropletSlug = "s-1vcpu-1gb";
+export let DropletS1VPCU2GB:     DropletSlug = "s-1vcpu-2gb";
+export let DropletS1VPCU3GB:     DropletSlug = "s-1vcpu-3gb";
+export let DropletS2VPCU2GB:     DropletSlug = "s-2vcpu-2gb";
+export let DropletS2VPCU4GB:     DropletSlug = "s-2vcpu-4gb";
+export let DropletS3VPCU1GB:     DropletSlug = "s-3vcpu-1gb";
+export let DropletS4VPCU8GB:     DropletSlug = "s-4vcpu-8gb";
+export let DropletS6VPCU16GB:    DropletSlug = "s-6vcpu-16gb";
+export let DropletS8VPCU32GB:    DropletSlug = "s-8vcpu-32gb";
+export let DropletS12VPCU48GB:   DropletSlug = "s-12vcpu-48gb";
+export let DropletS16VPCU64GB:   DropletSlug = "s-16vcpu-64gb";
+export let DropletS20VPCU96GB:   DropletSlug = "s-20vcpu-96gb";
+export let DropletS24VPCU128GB:  DropletSlug = "s-24vcpu-128gb";
+export let DropletS32VPCU192GB:  DropletSlug = "s-32vcpu-192gb";
+export let DropletG2VPCU8GB:     DropletSlug = "g-2vcpu-8gb";
+export let DropletG4VPCU16GB:    DropletSlug = "g-4vcpu-16gb";
+export let DropletG8VPCU32GB:    DropletSlug = "g-8vcpu-32gb";
+export let DropletG16VPCU64GB:   DropletSlug = "g-16vcpu-64gb";
+export let DropletG32VPCU128GB:  DropletSlug = "g-32vcpu-128gb";
+export let DropletG40VPCU160GB:  DropletSlug = "g-40vcpu-160gb";
+export let DropletGD2VPCU8GB:    DropletSlug = "gd-2vcpu-8gb";
+export let DropletGD4VPCU16GB:   DropletSlug = "gd-4vcpu-16gb";
+export let DropletGD8VPCU32GB:   DropletSlug = "gd-8vcpu-32gb";
+export let DropletGD16VPCU64GB:  DropletSlug = "gd-16vcpu-64gb";
+export let DropletGD32VPCU128GB: DropletSlug = "gd-32vcpu-128gb";
+export let DropletGD40VPCU160GB: DropletSlug = "gd-40vcpu-160gb";
+
+/**
+ * A DropletSlug represents any valid DigitalOcean droplet slug size that may be targeted for deployment.
+ */
+export type DropletSlug =
+    "512mb"           |
+    "1gb"             |
+    "2gb"             |
+    "4gb"             |
+    "8gb"             |
+    "16gb"            |
+    "32gb"            |
+    "48gb"            |
+    "64gb"            |
+    "c-2"             |
+    "c-4"             |
+    "c-8"             |
+    "c-16"            |
+    "c-32"            |
+    "s-1vcpu-1gb"     |
+    "s-1vcpu-2gb"     |
+    "s-1vcpu-3gb"     |
+    "s-2vcpu-2gb"     |
+    "s-2vcpu-4gb"     |
+    "s-3vcpu-1gb"     |
+    "s-4vcpu-8gb"     |
+    "s-6vcpu-16gb"    |
+    "s-8vcpu-32gb"    |
+    "s-12vcpu-48gb"   |
+    "s-16vcpu-64gb"   |
+    "s-20vcpu-96gb"   |
+    "s-24vcpu-128gb"  |
+    "s-32vcpu-192gb"  |
+    "g-2vcpu-8gb"     |
+    "g-4vcpu-16gb"    |
+    "g-8vcpu-32gb"    |
+    "g-16vcpu-64gb"   |
+    "g-32vcpu-128gb"  |
+    "g-40vcpu-160gb"  |
+    "gd-2vcpu-8gb"    |
+    "gd-4vcpu-16gb"   |
+    "gd-8vcpu-32gb"   |
+    "gd-16vcpu-64gb"  |
+    "gd-32vcpu-128gb" |
+    "gd-40vcpu-160gb" ;

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -9,6 +9,7 @@ export * from "./databaseSlug";
 export * from "./dnsRecord";
 export * from "./domain";
 export * from "./droplet";
+export * from "./dropletSlug";
 export * from "./dropletSnapshot";
 export * from "./firewall";
 export * from "./floatingIp";

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -5,6 +5,7 @@
 export * from "./cdn";
 export * from "./certificate";
 export * from "./databaseCluster";
+export * from "./databaseSlug";
 export * from "./dnsRecord";
 export * from "./domain";
 export * from "./droplet";

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -18,6 +18,7 @@
         "config/index.ts",
         "config/vars.ts",
         "databaseCluster.ts",
+        "databaseSlug.ts",
         "dnsRecord.ts",
         "domain.ts",
         "droplet.ts",

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -22,6 +22,7 @@
         "dnsRecord.ts",
         "domain.ts",
         "droplet.ts",
+        "dropletSlug.ts",
         "dropletSnapshot.ts",
         "firewall.ts",
         "floatingIp.ts",


### PR DESCRIPTION
Allows things like:

```
import * as digitalocean from "@pulumi/digitalocean";

 const web = new digitalocean.Droplet("web", {
     image: "ubuntu-18-04-x64",
     region: digitalocean.NYC1Region,
     size: digitalocean.DropletS1VPCU1GB,
 });
```

and

```
const example = new digitalocean.DatabaseCluster("example", {
    engine: "pg",
    nodeCount: 1,
    region: digitalocean.NYC1Region,
    size: digitalocean.Database1VPCU1GB,
    version: "11",
});
```