### PR TITLE
Add the ability to set an explicit domain name property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-___HEAD___
+* Add ability to set an explicit domain name via the `name` property on domain resource.
 
 ---
 

--- a/examples/databaseCluster/index.ts
+++ b/examples/databaseCluster/index.ts
@@ -17,7 +17,7 @@ import * as digitalocean from "@pulumi/digitalocean";
 const example = new digitalocean.DatabaseCluster("example", {
     engine: "pg",
     nodeCount: 1,
-    region: digitalocean.Regions.NYC1,
+    region: digitalocean.Regions.NYC3,
     size: digitalocean.DatabaseSlugs.DB_1VPCU1GB,
     version: "11",
 });

--- a/examples/domain/index.ts
+++ b/examples/domain/index.ts
@@ -14,6 +14,8 @@
 
 import * as digitalocean from "@pulumi/digitalocean";
 
-let domain = new digitalocean.Domain("pulumi-test.com");
+let domain = new digitalocean.Domain("my-domain", {
+    name: "my-domain.io"
+});
 
 export let name = domain.name;

--- a/examples/droplet/index.ts
+++ b/examples/droplet/index.ts
@@ -16,7 +16,7 @@ import * as digitalocean from "@pulumi/digitalocean";
 
  const web = new digitalocean.Droplet("web", {
      image: "ubuntu-18-04-x64",
-     region: digitalocean.Regions.NYC1,
+     region: digitalocean.Regions.NYC3,
      size: digitalocean.DropletSlugs.DropletS1VPCU1GB,
  });
 

--- a/examples/floatingip/index.ts
+++ b/examples/floatingip/index.ts
@@ -15,7 +15,7 @@
 import * as digitalocean from "@pulumi/digitalocean";
 
  const ip = new digitalocean.FloatingIp("ip", {
-     region: digitalocean.Regions.NYC1,
+     region: digitalocean.Regions.NYC3,
  });
 
  export let ipAddress = ip.ipAddress;

--- a/examples/loadbalancer/index.ts
+++ b/examples/loadbalancer/index.ts
@@ -18,7 +18,7 @@ const foobar = new digitalocean.Tag("foobar", {});
 
 const web = new digitalocean.Droplet("web", {
     image: "ubuntu-18-04-x64",
-    region: digitalocean.Regions.NYC1,
+    region: digitalocean.Regions.NYC3,
     size: "s-1vcpu-1gb",
     tags: [foobar.id],
 });
@@ -35,7 +35,7 @@ const lb = new digitalocean.LoadBalancer("public", {
         port: 22,
         protocol: "tcp",
     },
-    region: digitalocean.Regions.NYC1,
+    region: digitalocean.Regions.NYC3,
 });
 
 export let status = lb.status;

--- a/resources.go
+++ b/resources.go
@@ -112,7 +112,12 @@ func Provider() tfbridge.ProviderInfo {
 					},
 				},
 			},
-			"digitalocean_domain": {Tok: digitalOceanResource(digitalOceanMod, "Domain")},
+			"digitalocean_domain": {
+				Tok: digitalOceanResource(digitalOceanMod, "Domain"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": {Name: "name"},
+				},
+			},
 			"digitalocean_droplet": {
 				Tok: digitalOceanResource(digitalOceanMod, "Droplet"),
 				Fields: map[string]*tfbridge.SchemaInfo{

--- a/sdk/go/digitalocean/domain.go
+++ b/sdk/go/digitalocean/domain.go
@@ -4,6 +4,7 @@
 package digitalocean
 
 import (
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
@@ -15,6 +16,9 @@ type Domain struct {
 // NewDomain registers a new resource with the given unique name, arguments, and options.
 func NewDomain(ctx *pulumi.Context,
 	name string, args *DomainArgs, opts ...pulumi.ResourceOpt) (*Domain, error) {
+	if args == nil || args.Name == nil {
+		return nil, errors.New("missing required argument 'Name'")
+	}
 	inputs := make(map[string]interface{})
 	if args == nil {
 		inputs["ipAddress"] = nil

--- a/sdk/nodejs/dnsRecord.ts
+++ b/sdk/nodejs/dnsRecord.ts
@@ -16,7 +16,9 @@ import {RecordType} from "./index";
  * import * as digitalocean from "@pulumi/digitalocean";
  * 
  * // Create a new domain
- * const defaultDomain = new digitalocean.Domain("default", {});
+ * const defaultDomain = new digitalocean.Domain("default", {
+ *     name: "example.com",
+ * });
  * // Add a record to the domain
  * const www = new digitalocean.DnsRecord("www", {
  *     domain: defaultDomain.name,

--- a/sdk/nodejs/domain.ts
+++ b/sdk/nodejs/domain.ts
@@ -16,6 +16,7 @@ import * as utilities from "./utilities";
  * // Create a new domain
  * const defaultDomain = new digitalocean.Domain("default", {
  *     ipAddress: digitalocean_droplet_foo.ipv4Address,
+ *     name: "example.com",
  * });
  * ```
  */
@@ -67,7 +68,7 @@ export class Domain extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args?: DomainArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, args: DomainArgs, opts?: pulumi.CustomResourceOptions)
     constructor(name: string, argsOrState?: DomainArgs | DomainState, opts?: pulumi.CustomResourceOptions) {
         let inputs: pulumi.Inputs = {};
         if (opts && opts.id) {
@@ -77,6 +78,9 @@ export class Domain extends pulumi.CustomResource {
             inputs["urn"] = state ? state.urn : undefined;
         } else {
             const args = argsOrState as DomainArgs | undefined;
+            if (!args || args.name === undefined) {
+                throw new Error("Missing required property 'name'");
+            }
             inputs["ipAddress"] = args ? args.ipAddress : undefined;
             inputs["name"] = args ? args.name : undefined;
             inputs["urn"] = undefined /*out*/;
@@ -116,5 +120,5 @@ export interface DomainArgs {
     /**
      * The name of the domain
      */
-    readonly name?: pulumi.Input<string>;
+    readonly name: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_digitalocean/domain.py
+++ b/sdk/python/pulumi_digitalocean/domain.py
@@ -49,6 +49,8 @@ class Domain(pulumi.CustomResource):
 
         __props__['ip_address'] = ip_address
 
+        if name is None:
+            raise TypeError("Missing required property 'name'")
         __props__['name'] = name
 
         __props__['urn'] = None


### PR DESCRIPTION
This would stop the domain name having an autoappended name
which doesn't follow any sort of domain name structures

e.g. mydomain.io

when it used to be mydomain.io-bd3a25e