### PR TITLE
Update pulumi-terraform to 3635bed3a5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/miekg/dns v1.0.14 // indirect
 	github.com/pkg/errors v0.8.0
 	github.com/pulumi/pulumi v0.17.6-0.20190410045519-ef5e148a73c0
-	github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d
+	github.com/pulumi/pulumi-terraform v0.18.3
 	github.com/pulumi/scripts v0.0.0-20190410070955-3e8f41455b9c // indirect
 	github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 // indirect
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709

--- a/go.sum
+++ b/go.sum
@@ -540,6 +540,8 @@ github.com/pulumi/pulumi-terraform v0.18.2 h1:87eFAASBmHCH41OlcGZAydGgSYFTIPFoKj
 github.com/pulumi/pulumi-terraform v0.18.2/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d h1:ObOJbSfTnJ8IzrTw7pVcckU+R0yMEyV4mXdQ+xH+j8w=
 github.com/pulumi/pulumi-terraform v0.18.3-0.20190604214533-7ace3e9b5f2d/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
+github.com/pulumi/pulumi-terraform v0.18.3 h1:DHpETa+TWnthH9Sw3bHS+HxSgidB1cASkVqtQTW8jxg=
+github.com/pulumi/pulumi-terraform v0.18.3/go.mod h1:YHwPNWOBnQTnkibhfiyeShuSxwZnu7ZnKkqIvl0t2C0=
 github.com/pulumi/scripts v0.0.0-20190410070955-3e8f41455b9c h1:drINzqHlyUAhoSSn9bjUCfjg0RKLbD2166OXy/g1sxw=
 github.com/pulumi/scripts v0.0.0-20190410070955-3e8f41455b9c/go.mod h1:ZEj/wbB9HtXA9U6xWWpe9U+7vuDpiTIIt7Gca/XpfsA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -21,13 +21,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-   $ npm install @pulumi/digitalocean
+    $ npm install @pulumi/digitalocean
 
 or ``yarn``:
 
 ::
 
-   $ yarn add @pulumi/digitalocean
+    $ yarn add @pulumi/digitalocean
 
 Python
 ~~~~~~
@@ -36,7 +36,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-   $ pip install pulumi_digitalocean
+    $ pip install pulumi_digitalocean
 
 Go
 ~~
@@ -45,7 +45,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-   $ go get github.com/pulumi/pulumi-digitalocean/sdk/go/...
+    $ go get github.com/pulumi/pulumi-digitalocean/sdk/go/...
 
 Concepts
 --------

--- a/sdk/python/README.rst
+++ b/sdk/python/README.rst
@@ -21,13 +21,13 @@ To use from JavaScript or TypeScript in Node.js, install using either
 
 ::
 
-    $ npm install @pulumi/digitalocean
+   $ npm install @pulumi/digitalocean
 
 or ``yarn``:
 
 ::
 
-    $ yarn add @pulumi/digitalocean
+   $ yarn add @pulumi/digitalocean
 
 Python
 ~~~~~~
@@ -36,7 +36,7 @@ To use from Python, install using ``pip``:
 
 ::
 
-    $ pip install pulumi_digitalocean
+   $ pip install pulumi_digitalocean
 
 Go
 ~~
@@ -45,7 +45,7 @@ To use from Go, use ``go get`` to grab the latest version of the library
 
 ::
 
-    $ go get github.com/pulumi/pulumi-digitalocean/sdk/go/...
+   $ go get github.com/pulumi/pulumi-digitalocean/sdk/go/...
 
 Concepts
 --------


### PR DESCRIPTION
This PR updates `pulumi-terraform` to [3635bed3a5](https://github.com/pulumi/pulumi-terraform/commit/3635bed3a5c0250c3b22f02fde7845acd0dce3b6), and re-runs code generation