### PR TITLE
Fix invalid name of configuration value

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following configuration points are available:
   variables, ordered by precedence, `DIGITALOCEAN_TOKEN` or `DIGITALOCEAN_ACCESS_TOKEN`.
 - `digitalocean:spacesAccessId` - (Optional) The access key ID used for Spaces API operations. May be set via the 
   `SPACES_ACCESS_KEY_ID` environment variable.
-- `digitalocean:spacesSecretId` - (Optional) The access key ID used for Spaces API operations. May be set via the 
+- `digitalocean:spacesSecretKey` - (Optional) The access key ID used for Spaces API operations. May be set via the 
   `SPACES_SECRET_ACCESS_KEY` environment variable.
 - `digitalocean:apiEndpoint` - (Optional) This can be used to override the base URL for DigitalOcean API requests. May 
   be set via the `DIGITALOCEAN_API_URL` environment variable. Default is `https://api.digitalocean.com`.


### PR DESCRIPTION
The configuration value is not called `digitalocean:spacesSecretId` but `digitalocean:spacesSecretKey`.