### PR TITLE
Update go.mod with v4 path

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-digitalocean/sdk/v3
+module github.com/pulumi/pulumi-digitalocean/sdk/v4
 
 go 1.15
 


### PR DESCRIPTION
With version `v4.x`, the path should use the same versioning,
otherwise Go is angry and refuse to do its job.

From a new Pulumi project, the cli generates a `go.mod` file
and it wants to use `v4 / v4.2.0`, but instead on `go mod download`
we get this error:

```
go: github.com/pulumi/pulumi-digitalocean/sdk/v4@v4.2.0: sdk/go.mod has non-.../v4 module path "github.com/pulumi/pulumi-digitalocean/sdk/v3" (and .../v4/go.mod does not exist) at revision sdk/v4.2.0
```

Related issue: #235