### PR TITLE
Change instances of 'Digital Ocean' to 'DigitalOcean'

### DIFF
--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -251,7 +251,7 @@ _(none)_
 * Communicate detailed information about the difference between a resource's desired and actual state during a Pulumi update
 
 ## 0.18.6 (2019-07-04)
-* Upgraded to v1.5.0 of the Digital Ocean Terraform Provider
+* Upgraded to v1.5.0 of the DigitalOcean Terraform Provider
 
 ## 0.18.5 (2019-06-25)
 * Disable automatic naming for domain names. The `name` property on `Domain` resources is now required.
@@ -274,7 +274,7 @@ _(none)_
 * Add constants for File System types
 
 ## 0.18.1 (2019-05-31)
-* Upgraded to v1.4.0 of the Digital Ocean Terraform Provider
+* Upgraded to v1.4.0 of the DigitalOcean Terraform Provider
 
 ## 0.18.0 (2019-05-21)
 * Initial Release

--- a/provider/cmd/pulumi-resource-digitalocean/schema.json
+++ b/provider/cmd/pulumi-resource-digitalocean/schema.json
@@ -1,6 +1,6 @@
 {
     "name": "digitalocean",
-    "description": "A Pulumi package for creating and managing Digital Ocean cloud resources.",
+    "description": "A Pulumi package for creating and managing DigitalOcean cloud resources.",
     "keywords": [
         "pulumi",
         "digitalocean"
@@ -16620,7 +16620,7 @@
                         "items": {
                             "$ref": "#/types/digitalocean:index/getKubernetesClusterMaintenancePolicy:getKubernetesClusterMaintenancePolicy"
                         },
-                        "description": "The maintenance policy of the Kubernetes cluster. Digital Ocean has a default maintenancen window.\n"
+                        "description": "The maintenance policy of the Kubernetes cluster. DigitalOcean has a default maintenancen window.\n"
                     },
                     "name": {
                         "type": "string",
@@ -18114,7 +18114,7 @@
                 "@types/node": "^10.0.0"
             },
             "disableUnionOutputTypes": true,
-            "packageDescription": "A Pulumi package for creating and managing Digital Ocean cloud resources.",
+            "packageDescription": "A Pulumi package for creating and managing DigitalOcean cloud resources.",
             "packageName": "",
             "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/digitalocean/terraform-provider-digitalocean)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi/pulumi-digitalocean` repo](https://github.com/pulumi/pulumi-digitalocean/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`digitalocean/terraform-provider-digitalocean` repo](https://github.com/digitalocean/terraform-provider-digitalocean/issues).",
             "typescriptVersion": ""

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -36,18 +36,18 @@ const (
 	digitalOceanMod = "index" // the root index.
 )
 
-// makeMember manufactures a type token for the Digital Ocean package and the given module and type.
+// makeMember manufactures a type token for the DigitalOcean package and the given module and type.
 func makeMember(mod string, mem string) tokens.ModuleMember {
 	return tokens.ModuleMember(digitalOceanPkg + ":" + mod + ":" + mem)
 }
 
-// makeType manufactures a type token for the Digital Ocean package and the given module and type.
+// makeType manufactures a type token for the DigitalOcean package and the given module and type.
 func makeType(mod string, typ string) tokens.Type {
 	return tokens.Type(makeMember(mod, typ))
 }
 
 // makeDataSource manufactures a standard resource token given a module and resource name.
-// It automatically uses the Digital Ocean package and names the file by simply lower casing the data
+// It automatically uses the DigitalOcean package and names the file by simply lower casing the data
 // source's first character.
 func makeDataSource(mod string, res string) tokens.ModuleMember {
 	fn := string(unicode.ToLower(rune(res[0]))) + res[1:]
@@ -62,13 +62,13 @@ func makeResource(mod string, res string) tokens.Type {
 	return makeType(mod+"/"+fn, res)
 }
 
-// Provider returns additional overlaid schema and metadata associated with the Digital Ocean package.
+// Provider returns additional overlaid schema and metadata associated with the DigitalOcean package.
 func Provider() tfbridge.ProviderInfo {
 	p := shimv2.NewProvider(digitalocean.Provider())
 	prov := tfbridge.ProviderInfo{
 		P:           p,
 		Name:        "digitalocean",
-		Description: "A Pulumi package for creating and managing Digital Ocean cloud resources.",
+		Description: "A Pulumi package for creating and managing DigitalOcean cloud resources.",
 		Keywords:    []string{"pulumi", "digitalocean"},
 		License:     "Apache-2.0",
 		Homepage:    "https://pulumi.io",

--- a/sdk/dotnet/Config/README.md
+++ b/sdk/dotnet/Config/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Digital Ocean cloud resources.
+A Pulumi package for creating and managing DigitalOcean cloud resources.

--- a/sdk/dotnet/Pulumi.DigitalOcean.csproj
+++ b/sdk/dotnet/Pulumi.DigitalOcean.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi Corp.</Authors>
     <Company>Pulumi Corp.</Company>
-    <Description>A Pulumi package for creating and managing Digital Ocean cloud resources.</Description>
+    <Description>A Pulumi package for creating and managing DigitalOcean cloud resources.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://pulumi.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-digitalocean</RepositoryUrl>

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -1,1 +1,1 @@
-A Pulumi package for creating and managing Digital Ocean cloud resources.
+A Pulumi package for creating and managing DigitalOcean cloud resources.

--- a/sdk/go/digitalocean/doc.go
+++ b/sdk/go/digitalocean/doc.go
@@ -1,3 +1,3 @@
-// A Pulumi package for creating and managing Digital Ocean cloud resources.
+// A Pulumi package for creating and managing DigitalOcean cloud resources.
 //
 package digitalocean

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pulumi/digitalocean",
     "version": "${VERSION}",
-    "description": "A Pulumi package for creating and managing Digital Ocean cloud resources.",
+    "description": "A Pulumi package for creating and managing DigitalOcean cloud resources.",
     "keywords": [
         "pulumi",
         "digitalocean"

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -39,7 +39,7 @@ def readme():
 
 setup(name='pulumi_digitalocean',
       version=VERSION,
-      description="A Pulumi package for creating and managing Digital Ocean cloud resources.",
+      description="A Pulumi package for creating and managing DigitalOcean cloud resources.",
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={


### PR DESCRIPTION
This PR addresses https://github.com/pulumi/pulumi-digitalocean/issues/314

Before closing that issue, however, someone should adjust the name "Digital Ocean" in the "About" section of the README. I don't have the (admin?) access that I need to make the change myself. See #314 for a screenshot.