### PR TITLE
Create appUrn alias field

### DIFF
--- a/provider/cmd/pulumi-resource-digitalocean/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-digitalocean/bridge-metadata.json
@@ -1960,6 +1960,7 @@
             },
             "digitalocean:index/app:App": {
                 "activeDeploymentId": "active_deployment_id",
+                "appUrn": "urn",
                 "createdAt": "created_at",
                 "defaultIngress": "default_ingress",
                 "liveUrl": "live_url",

--- a/provider/cmd/pulumi-resource-digitalocean/schema.json
+++ b/provider/cmd/pulumi-resource-digitalocean/schema.json
@@ -6690,6 +6690,10 @@
                     "type": "string",
                     "description": "The ID the app's currently active deployment.\n"
                 },
+                "appUrn": {
+                    "type": "string",
+                    "description": "The uniform resource identifier for the app.\n"
+                },
                 "createdAt": {
                     "type": "string",
                     "description": "The date and time of when the app was created.\n"
@@ -6709,10 +6713,6 @@
                 "updatedAt": {
                     "type": "string",
                     "description": "The date and time of when the app was last updated.\n"
-                },
-                "urn": {
-                    "type": "string",
-                    "description": "The uniform resource identifier for the app.\n"
                 }
             },
             "required": [
@@ -6721,7 +6721,7 @@
                 "defaultIngress",
                 "liveUrl",
                 "updatedAt",
-                "urn"
+                "appUrn"
             ],
             "inputProperties": {
                 "spec": {
@@ -6735,6 +6735,10 @@
                     "activeDeploymentId": {
                         "type": "string",
                         "description": "The ID the app's currently active deployment.\n"
+                    },
+                    "appUrn": {
+                        "type": "string",
+                        "description": "The uniform resource identifier for the app.\n"
                     },
                     "createdAt": {
                         "type": "string",
@@ -6755,10 +6759,6 @@
                     "updatedAt": {
                         "type": "string",
                         "description": "The date and time of when the app was last updated.\n"
-                    },
-                    "urn": {
-                        "type": "string",
-                        "description": "The uniform resource identifier for the app.\n"
                     }
                 },
                 "type": "object"

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -275,9 +275,7 @@ func Provider() tfbridge.ProviderInfo {
 			"digitalocean_app": {
 				Tok: makeResource(digitalOceanMod, "App"),
 				Fields: map[string]*tfbridge.SchemaInfo{
-					"urn": {
-						Name: "appUrn",
-					},
+					"urn": { Name: "appUrn" },
 					"spec": {
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -275,6 +275,9 @@ func Provider() tfbridge.ProviderInfo {
 			"digitalocean_app": {
 				Tok: makeResource(digitalOceanMod, "App"),
 				Fields: map[string]*tfbridge.SchemaInfo{
+					"urn": {
+						Name: "appUrn",
+					},
 					"spec": {
 						Elem: &tfbridge.SchemaInfo{
 							Fields: map[string]*tfbridge.SchemaInfo{

--- a/sdk/dotnet/App.cs
+++ b/sdk/dotnet/App.cs
@@ -105,6 +105,12 @@ namespace Pulumi.DigitalOcean
         public Output<string> ActiveDeploymentId { get; private set; } = null!;
 
         /// <summary>
+        /// The uniform resource identifier for the app.
+        /// </summary>
+        [Output("appUrn")]
+        public Output<string> AppUrn { get; private set; } = null!;
+
+        /// <summary>
         /// The date and time of when the app was created.
         /// </summary>
         [Output("createdAt")]
@@ -133,12 +139,6 @@ namespace Pulumi.DigitalOcean
         /// </summary>
         [Output("updatedAt")]
         public Output<string> UpdatedAt { get; private set; } = null!;
-
-        /// <summary>
-        /// The uniform resource identifier for the app.
-        /// </summary>
-        [Output("urn")]
-        public Output<string> Urn { get; private set; } = null!;
 
 
         /// <summary>
@@ -207,6 +207,12 @@ namespace Pulumi.DigitalOcean
         public Input<string>? ActiveDeploymentId { get; set; }
 
         /// <summary>
+        /// The uniform resource identifier for the app.
+        /// </summary>
+        [Input("appUrn")]
+        public Input<string>? AppUrn { get; set; }
+
+        /// <summary>
         /// The date and time of when the app was created.
         /// </summary>
         [Input("createdAt")]
@@ -235,12 +241,6 @@ namespace Pulumi.DigitalOcean
         /// </summary>
         [Input("updatedAt")]
         public Input<string>? UpdatedAt { get; set; }
-
-        /// <summary>
-        /// The uniform resource identifier for the app.
-        /// </summary>
-        [Input("urn")]
-        public Input<string>? Urn { get; set; }
 
         public AppState()
         {

--- a/sdk/go/digitalocean/app.go
+++ b/sdk/go/digitalocean/app.go
@@ -109,6 +109,8 @@ type App struct {
 
 	// The ID the app's currently active deployment.
 	ActiveDeploymentId pulumi.StringOutput `pulumi:"activeDeploymentId"`
+	// The uniform resource identifier for the app.
+	AppUrn pulumi.StringOutput `pulumi:"appUrn"`
 	// The date and time of when the app was created.
 	CreatedAt pulumi.StringOutput `pulumi:"createdAt"`
 	// The default URL to access the app.
@@ -119,8 +121,6 @@ type App struct {
 	Spec AppSpecPtrOutput `pulumi:"spec"`
 	// The date and time of when the app was last updated.
 	UpdatedAt pulumi.StringOutput `pulumi:"updatedAt"`
-	// The uniform resource identifier for the app.
-	Urn pulumi.StringOutput `pulumi:"urn"`
 }
 
 // NewApp registers a new resource with the given unique name, arguments, and options.
@@ -154,6 +154,8 @@ func GetApp(ctx *pulumi.Context,
 type appState struct {
 	// The ID the app's currently active deployment.
 	ActiveDeploymentId *string `pulumi:"activeDeploymentId"`
+	// The uniform resource identifier for the app.
+	AppUrn *string `pulumi:"appUrn"`
 	// The date and time of when the app was created.
 	CreatedAt *string `pulumi:"createdAt"`
 	// The default URL to access the app.
@@ -164,13 +166,13 @@ type appState struct {
 	Spec *AppSpec `pulumi:"spec"`
 	// The date and time of when the app was last updated.
 	UpdatedAt *string `pulumi:"updatedAt"`
-	// The uniform resource identifier for the app.
-	Urn *string `pulumi:"urn"`
 }
 
 type AppState struct {
 	// The ID the app's currently active deployment.
 	ActiveDeploymentId pulumi.StringPtrInput
+	// The uniform resource identifier for the app.
+	AppUrn pulumi.StringPtrInput
 	// The date and time of when the app was created.
 	CreatedAt pulumi.StringPtrInput
 	// The default URL to access the app.
@@ -181,8 +183,6 @@ type AppState struct {
 	Spec AppSpecPtrInput
 	// The date and time of when the app was last updated.
 	UpdatedAt pulumi.StringPtrInput
-	// The uniform resource identifier for the app.
-	Urn pulumi.StringPtrInput
 }
 
 func (AppState) ElementType() reflect.Type {
@@ -292,6 +292,11 @@ func (o AppOutput) ActiveDeploymentId() pulumi.StringOutput {
 	return o.ApplyT(func(v *App) pulumi.StringOutput { return v.ActiveDeploymentId }).(pulumi.StringOutput)
 }
 
+// The uniform resource identifier for the app.
+func (o AppOutput) AppUrn() pulumi.StringOutput {
+	return o.ApplyT(func(v *App) pulumi.StringOutput { return v.AppUrn }).(pulumi.StringOutput)
+}
+
 // The date and time of when the app was created.
 func (o AppOutput) CreatedAt() pulumi.StringOutput {
 	return o.ApplyT(func(v *App) pulumi.StringOutput { return v.CreatedAt }).(pulumi.StringOutput)
@@ -315,11 +320,6 @@ func (o AppOutput) Spec() AppSpecPtrOutput {
 // The date and time of when the app was last updated.
 func (o AppOutput) UpdatedAt() pulumi.StringOutput {
 	return o.ApplyT(func(v *App) pulumi.StringOutput { return v.UpdatedAt }).(pulumi.StringOutput)
-}
-
-// The uniform resource identifier for the app.
-func (o AppOutput) Urn() pulumi.StringOutput {
-	return o.ApplyT(func(v *App) pulumi.StringOutput { return v.Urn }).(pulumi.StringOutput)
 }
 
 type AppArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/digitalocean/App.java
+++ b/sdk/java/src/main/java/com/pulumi/digitalocean/App.java
@@ -207,6 +207,20 @@ public class App extends com.pulumi.resources.CustomResource {
         return this.activeDeploymentId;
     }
     /**
+     * The uniform resource identifier for the app.
+     * 
+     */
+    @Export(name="appUrn", type=String.class, parameters={})
+    private Output<String> appUrn;
+
+    /**
+     * @return The uniform resource identifier for the app.
+     * 
+     */
+    public Output<String> appUrn() {
+        return this.appUrn;
+    }
+    /**
      * The date and time of when the app was created.
      * 
      */
@@ -275,20 +289,6 @@ public class App extends com.pulumi.resources.CustomResource {
      */
     public Output<String> updatedAt() {
         return this.updatedAt;
-    }
-    /**
-     * The uniform resource identifier for the app.
-     * 
-     */
-    @Export(name="urn", type=String.class, parameters={})
-    private Output<String> urn;
-
-    /**
-     * @return The uniform resource identifier for the app.
-     * 
-     */
-    public Output<String> urn() {
-        return this.urn;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/digitalocean/inputs/AppState.java
+++ b/sdk/java/src/main/java/com/pulumi/digitalocean/inputs/AppState.java
@@ -32,6 +32,21 @@ public final class AppState extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The uniform resource identifier for the app.
+     * 
+     */
+    @Import(name="appUrn")
+    private @Nullable Output<String> appUrn;
+
+    /**
+     * @return The uniform resource identifier for the app.
+     * 
+     */
+    public Optional<Output<String>> appUrn() {
+        return Optional.ofNullable(this.appUrn);
+    }
+
+    /**
      * The date and time of when the app was created.
      * 
      */
@@ -106,31 +121,16 @@ public final class AppState extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.updatedAt);
     }
 
-    /**
-     * The uniform resource identifier for the app.
-     * 
-     */
-    @Import(name="urn")
-    private @Nullable Output<String> urn;
-
-    /**
-     * @return The uniform resource identifier for the app.
-     * 
-     */
-    public Optional<Output<String>> urn() {
-        return Optional.ofNullable(this.urn);
-    }
-
     private AppState() {}
 
     private AppState(AppState $) {
         this.activeDeploymentId = $.activeDeploymentId;
+        this.appUrn = $.appUrn;
         this.createdAt = $.createdAt;
         this.defaultIngress = $.defaultIngress;
         this.liveUrl = $.liveUrl;
         this.spec = $.spec;
         this.updatedAt = $.updatedAt;
-        this.urn = $.urn;
     }
 
     public static Builder builder() {
@@ -170,6 +170,27 @@ public final class AppState extends com.pulumi.resources.ResourceArgs {
          */
         public Builder activeDeploymentId(String activeDeploymentId) {
             return activeDeploymentId(Output.of(activeDeploymentId));
+        }
+
+        /**
+         * @param appUrn The uniform resource identifier for the app.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder appUrn(@Nullable Output<String> appUrn) {
+            $.appUrn = appUrn;
+            return this;
+        }
+
+        /**
+         * @param appUrn The uniform resource identifier for the app.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder appUrn(String appUrn) {
+            return appUrn(Output.of(appUrn));
         }
 
         /**
@@ -275,27 +296,6 @@ public final class AppState extends com.pulumi.resources.ResourceArgs {
          */
         public Builder updatedAt(String updatedAt) {
             return updatedAt(Output.of(updatedAt));
-        }
-
-        /**
-         * @param urn The uniform resource identifier for the app.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder urn(@Nullable Output<String> urn) {
-            $.urn = urn;
-            return this;
-        }
-
-        /**
-         * @param urn The uniform resource identifier for the app.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder urn(String urn) {
-            return urn(Output.of(urn));
         }
 
         public AppState build() {

--- a/sdk/nodejs/app.ts
+++ b/sdk/nodejs/app.ts
@@ -96,6 +96,10 @@ export class App extends pulumi.CustomResource {
      */
     public /*out*/ readonly activeDeploymentId!: pulumi.Output<string>;
     /**
+     * The uniform resource identifier for the app.
+     */
+    public /*out*/ readonly appUrn!: pulumi.Output<string>;
+    /**
      * The date and time of when the app was created.
      */
     public /*out*/ readonly createdAt!: pulumi.Output<string>;
@@ -115,10 +119,6 @@ export class App extends pulumi.CustomResource {
      * The date and time of when the app was last updated.
      */
     public /*out*/ readonly updatedAt!: pulumi.Output<string>;
-    /**
-     * The uniform resource identifier for the app.
-     */
-    public /*out*/ readonly urn!: pulumi.Output<string>;
 
     /**
      * Create a App resource with the given unique name, arguments, and options.
@@ -134,21 +134,21 @@ export class App extends pulumi.CustomResource {
         if (opts.id) {
             const state = argsOrState as AppState | undefined;
             resourceInputs["activeDeploymentId"] = state ? state.activeDeploymentId : undefined;
+            resourceInputs["appUrn"] = state ? state.appUrn : undefined;
             resourceInputs["createdAt"] = state ? state.createdAt : undefined;
             resourceInputs["defaultIngress"] = state ? state.defaultIngress : undefined;
             resourceInputs["liveUrl"] = state ? state.liveUrl : undefined;
             resourceInputs["spec"] = state ? state.spec : undefined;
             resourceInputs["updatedAt"] = state ? state.updatedAt : undefined;
-            resourceInputs["urn"] = state ? state.urn : undefined;
         } else {
             const args = argsOrState as AppArgs | undefined;
             resourceInputs["spec"] = args ? args.spec : undefined;
             resourceInputs["activeDeploymentId"] = undefined /*out*/;
+            resourceInputs["appUrn"] = undefined /*out*/;
             resourceInputs["createdAt"] = undefined /*out*/;
             resourceInputs["defaultIngress"] = undefined /*out*/;
             resourceInputs["liveUrl"] = undefined /*out*/;
             resourceInputs["updatedAt"] = undefined /*out*/;
-            resourceInputs["urn"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(App.__pulumiType, name, resourceInputs, opts);
@@ -163,6 +163,10 @@ export interface AppState {
      * The ID the app's currently active deployment.
      */
     activeDeploymentId?: pulumi.Input<string>;
+    /**
+     * The uniform resource identifier for the app.
+     */
+    appUrn?: pulumi.Input<string>;
     /**
      * The date and time of when the app was created.
      */
@@ -183,10 +187,6 @@ export interface AppState {
      * The date and time of when the app was last updated.
      */
     updatedAt?: pulumi.Input<string>;
-    /**
-     * The uniform resource identifier for the app.
-     */
-    urn?: pulumi.Input<string>;
 }
 
 /**

--- a/sdk/python/pulumi_digitalocean/app.py
+++ b/sdk/python/pulumi_digitalocean/app.py
@@ -41,24 +41,26 @@ class AppArgs:
 class _AppState:
     def __init__(__self__, *,
                  active_deployment_id: Optional[pulumi.Input[str]] = None,
+                 app_urn: Optional[pulumi.Input[str]] = None,
                  created_at: Optional[pulumi.Input[str]] = None,
                  default_ingress: Optional[pulumi.Input[str]] = None,
                  live_url: Optional[pulumi.Input[str]] = None,
                  spec: Optional[pulumi.Input['AppSpecArgs']] = None,
-                 updated_at: Optional[pulumi.Input[str]] = None,
-                 urn: Optional[pulumi.Input[str]] = None):
+                 updated_at: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering App resources.
         :param pulumi.Input[str] active_deployment_id: The ID the app's currently active deployment.
+        :param pulumi.Input[str] app_urn: The uniform resource identifier for the app.
         :param pulumi.Input[str] created_at: The date and time of when the app was created.
         :param pulumi.Input[str] default_ingress: The default URL to access the app.
         :param pulumi.Input[str] live_url: The live URL of the app.
         :param pulumi.Input['AppSpecArgs'] spec: A DigitalOcean App spec describing the app.
         :param pulumi.Input[str] updated_at: The date and time of when the app was last updated.
-        :param pulumi.Input[str] urn: The uniform resource identifier for the app.
         """
         if active_deployment_id is not None:
             pulumi.set(__self__, "active_deployment_id", active_deployment_id)
+        if app_urn is not None:
+            pulumi.set(__self__, "app_urn", app_urn)
         if created_at is not None:
             pulumi.set(__self__, "created_at", created_at)
         if default_ingress is not None:
@@ -69,8 +71,6 @@ class _AppState:
             pulumi.set(__self__, "spec", spec)
         if updated_at is not None:
             pulumi.set(__self__, "updated_at", updated_at)
-        if urn is not None:
-            pulumi.set(__self__, "urn", urn)
 
     @property
     @pulumi.getter(name="activeDeploymentId")
@@ -83,6 +83,18 @@ class _AppState:
     @active_deployment_id.setter
     def active_deployment_id(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "active_deployment_id", value)
+
+    @property
+    @pulumi.getter(name="appUrn")
+    def app_urn(self) -> Optional[pulumi.Input[str]]:
+        """
+        The uniform resource identifier for the app.
+        """
+        return pulumi.get(self, "app_urn")
+
+    @app_urn.setter
+    def app_urn(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "app_urn", value)
 
     @property
     @pulumi.getter(name="createdAt")
@@ -143,18 +155,6 @@ class _AppState:
     @updated_at.setter
     def updated_at(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "updated_at", value)
-
-    @property
-    @pulumi.getter
-    def urn(self) -> Optional[pulumi.Input[str]]:
-        """
-        The uniform resource identifier for the app.
-        """
-        return pulumi.get(self, "urn")
-
-    @urn.setter
-    def urn(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "urn", value)
 
 
 class App(pulumi.CustomResource):
@@ -313,11 +313,11 @@ class App(pulumi.CustomResource):
 
             __props__.__dict__["spec"] = spec
             __props__.__dict__["active_deployment_id"] = None
+            __props__.__dict__["app_urn"] = None
             __props__.__dict__["created_at"] = None
             __props__.__dict__["default_ingress"] = None
             __props__.__dict__["live_url"] = None
             __props__.__dict__["updated_at"] = None
-            __props__.__dict__["urn"] = None
         super(App, __self__).__init__(
             'digitalocean:index/app:App',
             resource_name,
@@ -329,12 +329,12 @@ class App(pulumi.CustomResource):
             id: pulumi.Input[str],
             opts: Optional[pulumi.ResourceOptions] = None,
             active_deployment_id: Optional[pulumi.Input[str]] = None,
+            app_urn: Optional[pulumi.Input[str]] = None,
             created_at: Optional[pulumi.Input[str]] = None,
             default_ingress: Optional[pulumi.Input[str]] = None,
             live_url: Optional[pulumi.Input[str]] = None,
             spec: Optional[pulumi.Input[pulumi.InputType['AppSpecArgs']]] = None,
-            updated_at: Optional[pulumi.Input[str]] = None,
-            urn: Optional[pulumi.Input[str]] = None) -> 'App':
+            updated_at: Optional[pulumi.Input[str]] = None) -> 'App':
         """
         Get an existing App resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -343,24 +343,24 @@ class App(pulumi.CustomResource):
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] active_deployment_id: The ID the app's currently active deployment.
+        :param pulumi.Input[str] app_urn: The uniform resource identifier for the app.
         :param pulumi.Input[str] created_at: The date and time of when the app was created.
         :param pulumi.Input[str] default_ingress: The default URL to access the app.
         :param pulumi.Input[str] live_url: The live URL of the app.
         :param pulumi.Input[pulumi.InputType['AppSpecArgs']] spec: A DigitalOcean App spec describing the app.
         :param pulumi.Input[str] updated_at: The date and time of when the app was last updated.
-        :param pulumi.Input[str] urn: The uniform resource identifier for the app.
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
         __props__ = _AppState.__new__(_AppState)
 
         __props__.__dict__["active_deployment_id"] = active_deployment_id
+        __props__.__dict__["app_urn"] = app_urn
         __props__.__dict__["created_at"] = created_at
         __props__.__dict__["default_ingress"] = default_ingress
         __props__.__dict__["live_url"] = live_url
         __props__.__dict__["spec"] = spec
         __props__.__dict__["updated_at"] = updated_at
-        __props__.__dict__["urn"] = urn
         return App(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -370,6 +370,14 @@ class App(pulumi.CustomResource):
         The ID the app's currently active deployment.
         """
         return pulumi.get(self, "active_deployment_id")
+
+    @property
+    @pulumi.getter(name="appUrn")
+    def app_urn(self) -> pulumi.Output[str]:
+        """
+        The uniform resource identifier for the app.
+        """
+        return pulumi.get(self, "app_urn")
 
     @property
     @pulumi.getter(name="createdAt")
@@ -410,12 +418,4 @@ class App(pulumi.CustomResource):
         The date and time of when the app was last updated.
         """
         return pulumi.get(self, "updated_at")
-
-    @property
-    @pulumi.getter
-    def urn(self) -> pulumi.Output[str]:
-        """
-        The uniform resource identifier for the app.
-        """
-        return pulumi.get(self, "urn")
 


### PR DESCRIPTION
Fixes #462 

Aliases the DigitalOcean urn for App resources to `appUrn` to be usable.