### PR TITLE
Fix urn name clash for ReservedIp resource in DigitalOcean provider

### DIFF
--- a/provider/cmd/pulumi-resource-digitalocean/bridge-metadata.json
+++ b/provider/cmd/pulumi-resource-digitalocean/bridge-metadata.json
@@ -2694,7 +2694,8 @@
             },
             "digitalocean:index/reservedIp:ReservedIp": {
                 "dropletId": "droplet_id",
-                "ipAddress": "ip_address"
+                "ipAddress": "ip_address",
+                "reservedIpUrn": "urn"
             },
             "digitalocean:index/reservedIpAssignment:ReservedIpAssignment": {
                 "dropletId": "droplet_id",

--- a/provider/cmd/pulumi-resource-digitalocean/schema.json
+++ b/provider/cmd/pulumi-resource-digitalocean/schema.json
@@ -10561,7 +10561,7 @@
                     "type": "string",
                     "description": "The region that the reserved IP is reserved to.\n"
                 },
-                "urn": {
+                "reservedIpUrn": {
                     "type": "string",
                     "description": "The uniform resource name of the reserved ip\n"
                 }
@@ -10569,7 +10569,7 @@
             "required": [
                 "ipAddress",
                 "region",
-                "urn"
+                "reservedIpUrn"
             ],
             "inputProperties": {
                 "dropletId": {
@@ -10605,7 +10605,7 @@
                         "description": "The region that the reserved IP is reserved to.\n",
                         "willReplaceOnChanges": true
                     },
-                    "urn": {
+                    "reservedIpUrn": {
                         "type": "string",
                         "description": "The uniform resource name of the reserved ip\n"
                     }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -290,7 +290,14 @@ func Provider() tfbridge.ProviderInfo {
 			"digitalocean_custom_image":           {Tok: makeResource(digitalOceanMod, "CustomImage")},
 			"digitalocean_monitor_alert":          {Tok: makeResource(digitalOceanMod, "MonitorAlert")},
 			"digitalocean_spaces_bucket_policy":   {Tok: makeResource(digitalOceanMod, "SpacesBucketPolicy")},
-			"digitalocean_reserved_ip":            {Tok: makeResource(digitalOceanMod, "ReservedIp")},
+			"digitalocean_reserved_ip":            {
+				Tok: makeResource(digitalOceanMod, "ReservedIp"),
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"urn": {
+						Name: "reservedIpUrn",
+					},
+				},
+			},
 			"digitalocean_reserved_ip_assignment": {Tok: makeResource(digitalOceanMod, "ReservedIpAssignment")},
 		},
 		ExtraTypes: map[string]schema.ComplexTypeSpec{

--- a/sdk/dotnet/ReservedIp.cs
+++ b/sdk/dotnet/ReservedIp.cs
@@ -74,8 +74,8 @@ namespace Pulumi.DigitalOcean
         /// <summary>
         /// The uniform resource name of the reserved ip
         /// </summary>
-        [Output("urn")]
-        public Output<string> Urn { get; private set; } = null!;
+        [Output("reservedIpUrn")]
+        public Output<string> ReservedIpUrn { get; private set; } = null!;
 
 
         /// <summary>
@@ -170,8 +170,8 @@ namespace Pulumi.DigitalOcean
         /// <summary>
         /// The uniform resource name of the reserved ip
         /// </summary>
-        [Input("urn")]
-        public Input<string>? Urn { get; set; }
+        [Input("reservedIpUrn")]
+        public Input<string>? ReservedIpUrn { get; set; }
 
         public ReservedIpState()
         {

--- a/sdk/go/digitalocean/reservedIp.go
+++ b/sdk/go/digitalocean/reservedIp.go
@@ -73,7 +73,7 @@ type ReservedIp struct {
 	// The region that the reserved IP is reserved to.
 	Region pulumi.StringOutput `pulumi:"region"`
 	// The uniform resource name of the reserved ip
-	Urn pulumi.StringOutput `pulumi:"urn"`
+	ReservedIpUrn pulumi.StringOutput `pulumi:"reservedIpUrn"`
 }
 
 // NewReservedIp registers a new resource with the given unique name, arguments, and options.
@@ -116,7 +116,7 @@ type reservedIpState struct {
 	// The region that the reserved IP is reserved to.
 	Region *string `pulumi:"region"`
 	// The uniform resource name of the reserved ip
-	Urn *string `pulumi:"urn"`
+	ReservedIpUrn *string `pulumi:"reservedIpUrn"`
 }
 
 type ReservedIpState struct {
@@ -127,7 +127,7 @@ type ReservedIpState struct {
 	// The region that the reserved IP is reserved to.
 	Region pulumi.StringPtrInput
 	// The uniform resource name of the reserved ip
-	Urn pulumi.StringPtrInput
+	ReservedIpUrn pulumi.StringPtrInput
 }
 
 func (ReservedIpState) ElementType() reflect.Type {
@@ -280,8 +280,8 @@ func (o ReservedIpOutput) Region() pulumi.StringOutput {
 }
 
 // The uniform resource name of the reserved ip
-func (o ReservedIpOutput) Urn() pulumi.StringOutput {
-	return o.ApplyT(func(v *ReservedIp) pulumi.StringOutput { return v.Urn }).(pulumi.StringOutput)
+func (o ReservedIpOutput) ReservedIpUrn() pulumi.StringOutput {
+	return o.ApplyT(func(v *ReservedIp) pulumi.StringOutput { return v.ReservedIpUrn }).(pulumi.StringOutput)
 }
 
 type ReservedIpArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/digitalocean/ReservedIp.java
+++ b/sdk/java/src/main/java/com/pulumi/digitalocean/ReservedIp.java
@@ -118,15 +118,15 @@ public class ReservedIp extends com.pulumi.resources.CustomResource {
      * The uniform resource name of the reserved ip
      * 
      */
-    @Export(name="urn", type=String.class, parameters={})
-    private Output<String> urn;
+    @Export(name="reservedIpUrn", type=String.class, parameters={})
+    private Output<String> reservedIpUrn;
 
     /**
      * @return The uniform resource name of the reserved ip
      * 
      */
-    public Output<String> urn() {
-        return this.urn;
+    public Output<String> reservedIpUrn() {
+        return this.reservedIpUrn;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/digitalocean/inputs/ReservedIpState.java
+++ b/sdk/java/src/main/java/com/pulumi/digitalocean/inputs/ReservedIpState.java
@@ -65,15 +65,15 @@ public final class ReservedIpState extends com.pulumi.resources.ResourceArgs {
      * The uniform resource name of the reserved ip
      * 
      */
-    @Import(name="urn")
-    private @Nullable Output<String> urn;
+    @Import(name="reservedIpUrn")
+    private @Nullable Output<String> reservedIpUrn;
 
     /**
      * @return The uniform resource name of the reserved ip
      * 
      */
-    public Optional<Output<String>> urn() {
-        return Optional.ofNullable(this.urn);
+    public Optional<Output<String>> reservedIpUrn() {
+        return Optional.ofNullable(this.reservedIpUrn);
     }
 
     private ReservedIpState() {}
@@ -82,7 +82,7 @@ public final class ReservedIpState extends com.pulumi.resources.ResourceArgs {
         this.dropletId = $.dropletId;
         this.ipAddress = $.ipAddress;
         this.region = $.region;
-        this.urn = $.urn;
+        this.reservedIpUrn = $.reservedIpUrn;
     }
 
     public static Builder builder() {
@@ -167,24 +167,24 @@ public final class ReservedIpState extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param urn The uniform resource name of the reserved ip
+         * @param reservedIpUrn The uniform resource name of the reserved ip
          * 
          * @return builder
          * 
          */
-        public Builder urn(@Nullable Output<String> urn) {
-            $.urn = urn;
+        public Builder reservedIpUrn(@Nullable Output<String> reservedIpUrn) {
+            $.reservedIpUrn = reservedIpUrn;
             return this;
         }
 
         /**
-         * @param urn The uniform resource name of the reserved ip
+         * @param reservedIpUrn The uniform resource name of the reserved ip
          * 
          * @return builder
          * 
          */
-        public Builder urn(String urn) {
-            return urn(Output.of(urn));
+        public Builder reservedIpUrn(String reservedIpUrn) {
+            return reservedIpUrn(Output.of(reservedIpUrn));
         }
 
         public ReservedIpState build() {

--- a/sdk/nodejs/reservedIp.ts
+++ b/sdk/nodejs/reservedIp.ts
@@ -79,7 +79,7 @@ export class ReservedIp extends pulumi.CustomResource {
     /**
      * The uniform resource name of the reserved ip
      */
-    public /*out*/ readonly urn!: pulumi.Output<string>;
+    public /*out*/ readonly reservedIpUrn!: pulumi.Output<string>;
 
     /**
      * Create a ReservedIp resource with the given unique name, arguments, and options.
@@ -97,7 +97,7 @@ export class ReservedIp extends pulumi.CustomResource {
             resourceInputs["dropletId"] = state ? state.dropletId : undefined;
             resourceInputs["ipAddress"] = state ? state.ipAddress : undefined;
             resourceInputs["region"] = state ? state.region : undefined;
-            resourceInputs["urn"] = state ? state.urn : undefined;
+            resourceInputs["reservedIpUrn"] = state ? state.reservedIpUrn : undefined;
         } else {
             const args = argsOrState as ReservedIpArgs | undefined;
             if ((!args || args.region === undefined) && !opts.urn) {
@@ -106,7 +106,7 @@ export class ReservedIp extends pulumi.CustomResource {
             resourceInputs["dropletId"] = args ? args.dropletId : undefined;
             resourceInputs["ipAddress"] = args ? args.ipAddress : undefined;
             resourceInputs["region"] = args ? args.region : undefined;
-            resourceInputs["urn"] = undefined /*out*/;
+            resourceInputs["reservedIpUrn"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(ReservedIp.__pulumiType, name, resourceInputs, opts);
@@ -132,7 +132,7 @@ export interface ReservedIpState {
     /**
      * The uniform resource name of the reserved ip
      */
-    urn?: pulumi.Input<string>;
+    reservedIpUrn?: pulumi.Input<string>;
 }
 
 /**

--- a/sdk/python/pulumi_digitalocean/reserved_ip.py
+++ b/sdk/python/pulumi_digitalocean/reserved_ip.py
@@ -93,20 +93,20 @@ class _ReservedIpState:
                  droplet_id: Optional[pulumi.Input[int]] = None,
                  ip_address: Optional[pulumi.Input[str]] = None,
                  region: Optional[pulumi.Input[str]] = None,
-                 urn: Optional[pulumi.Input[str]] = None):
+                 reserved_ip_urn: Optional[pulumi.Input[str]] = None):
         """
         Input properties used for looking up and filtering ReservedIp resources.
         :param pulumi.Input[int] droplet_id: The ID of Droplet that the reserved IP will be assigned to.
         :param pulumi.Input[str] ip_address: The IP Address of the resource
         :param pulumi.Input[str] region: The region that the reserved IP is reserved to.
-        :param pulumi.Input[str] urn: The uniform resource name of the reserved ip
+        :param pulumi.Input[str] reserved_ip_urn: The uniform resource name of the reserved ip
         """
         _ReservedIpState._configure(
             lambda key, value: pulumi.set(__self__, key, value),
             droplet_id=droplet_id,
             ip_address=ip_address,
             region=region,
-            urn=urn,
+            reserved_ip_urn=reserved_ip_urn,
         )
     @staticmethod
     def _configure(
@@ -114,13 +114,15 @@ class _ReservedIpState:
              droplet_id: Optional[pulumi.Input[int]] = None,
              ip_address: Optional[pulumi.Input[str]] = None,
              region: Optional[pulumi.Input[str]] = None,
-             urn: Optional[pulumi.Input[str]] = None,
+             reserved_ip_urn: Optional[pulumi.Input[str]] = None,
              opts: Optional[pulumi.ResourceOptions] = None,
              **kwargs):
         if droplet_id is None and 'dropletId' in kwargs:
             droplet_id = kwargs['dropletId']
         if ip_address is None and 'ipAddress' in kwargs:
             ip_address = kwargs['ipAddress']
+        if reserved_ip_urn is None and 'reservedIpUrn' in kwargs:
+            reserved_ip_urn = kwargs['reservedIpUrn']
 
         if droplet_id is not None:
             _setter("droplet_id", droplet_id)
@@ -128,8 +130,8 @@ class _ReservedIpState:
             _setter("ip_address", ip_address)
         if region is not None:
             _setter("region", region)
-        if urn is not None:
-            _setter("urn", urn)
+        if reserved_ip_urn is not None:
+            _setter("reserved_ip_urn", reserved_ip_urn)
 
     @property
     @pulumi.getter(name="dropletId")
@@ -168,16 +170,16 @@ class _ReservedIpState:
         pulumi.set(self, "region", value)
 
     @property
-    @pulumi.getter
-    def urn(self) -> Optional[pulumi.Input[str]]:
+    @pulumi.getter(name="reservedIpUrn")
+    def reserved_ip_urn(self) -> Optional[pulumi.Input[str]]:
         """
         The uniform resource name of the reserved ip
         """
-        return pulumi.get(self, "urn")
+        return pulumi.get(self, "reserved_ip_urn")
 
-    @urn.setter
-    def urn(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "urn", value)
+    @reserved_ip_urn.setter
+    def reserved_ip_urn(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "reserved_ip_urn", value)
 
 
 class ReservedIp(pulumi.CustomResource):
@@ -297,7 +299,7 @@ class ReservedIp(pulumi.CustomResource):
             if region is None and not opts.urn:
                 raise TypeError("Missing required property 'region'")
             __props__.__dict__["region"] = region
-            __props__.__dict__["urn"] = None
+            __props__.__dict__["reserved_ip_urn"] = None
         super(ReservedIp, __self__).__init__(
             'digitalocean:index/reservedIp:ReservedIp',
             resource_name,
@@ -311,7 +313,7 @@ class ReservedIp(pulumi.CustomResource):
             droplet_id: Optional[pulumi.Input[int]] = None,
             ip_address: Optional[pulumi.Input[str]] = None,
             region: Optional[pulumi.Input[str]] = None,
-            urn: Optional[pulumi.Input[str]] = None) -> 'ReservedIp':
+            reserved_ip_urn: Optional[pulumi.Input[str]] = None) -> 'ReservedIp':
         """
         Get an existing ReservedIp resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -322,7 +324,7 @@ class ReservedIp(pulumi.CustomResource):
         :param pulumi.Input[int] droplet_id: The ID of Droplet that the reserved IP will be assigned to.
         :param pulumi.Input[str] ip_address: The IP Address of the resource
         :param pulumi.Input[str] region: The region that the reserved IP is reserved to.
-        :param pulumi.Input[str] urn: The uniform resource name of the reserved ip
+        :param pulumi.Input[str] reserved_ip_urn: The uniform resource name of the reserved ip
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -331,7 +333,7 @@ class ReservedIp(pulumi.CustomResource):
         __props__.__dict__["droplet_id"] = droplet_id
         __props__.__dict__["ip_address"] = ip_address
         __props__.__dict__["region"] = region
-        __props__.__dict__["urn"] = urn
+        __props__.__dict__["reserved_ip_urn"] = reserved_ip_urn
         return ReservedIp(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -359,10 +361,10 @@ class ReservedIp(pulumi.CustomResource):
         return pulumi.get(self, "region")
 
     @property
-    @pulumi.getter
-    def urn(self) -> pulumi.Output[str]:
+    @pulumi.getter(name="reservedIpUrn")
+    def reserved_ip_urn(self) -> pulumi.Output[str]:
         """
         The uniform resource name of the reserved ip
         """
-        return pulumi.get(self, "urn")
+        return pulumi.get(self, "reserved_ip_urn")
 


### PR DESCRIPTION
I'm not sure if this solves the whole thing but it seems all the other DO resources that have an URN field use this trick to rename it in generated schema.