### PR TITLE
Enable zero default schema version for digitalocean

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -594,8 +594,8 @@ func Provider() tfbridge.ProviderInfo {
 				"digitalocean": "DigitalOcean",
 			},
 		},
-		MetadataInfo: tfbridge.NewProviderMetadata(metadata),
-		Version:      version.Version,
+		MetadataInfo:                   tfbridge.NewProviderMetadata(metadata),
+		Version:                        version.Version,
 		EnableZeroDefaultSchemaVersion: true,
 	}
 

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -596,6 +596,7 @@ func Provider() tfbridge.ProviderInfo {
 		},
 		MetadataInfo: tfbridge.NewProviderMetadata(metadata),
 		Version:      version.Version,
+		EnableZeroDefaultSchemaVersion: true,
 	}
 
 	defaults := tfbridgetokens.SingleModule("digitalocean_", digitalOceanMod, tfbridgetokens.MakeStandard(digitalOceanPkg))


### PR DESCRIPTION
Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2133

Enables zero default schema version for digitalocean.