### PR TITLE
Set `.DisplayName` in `tfbridge.ProviderInfo`

### DIFF
--- a/provider/cmd/pulumi-resource-digitalocean/schema.json
+++ b/provider/cmd/pulumi-resource-digitalocean/schema.json
@@ -1,5 +1,6 @@
 {
     "name": "digitalocean",
+    "displayName": "DigitalOcean",
     "description": "A Pulumi package for creating and managing DigitalOcean cloud resources.",
     "keywords": [
         "pulumi",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -76,6 +76,7 @@ func Provider() tfbridge.ProviderInfo {
 	prov := tfbridge.ProviderInfo{
 		P:                p,
 		Name:             "digitalocean",
+		DisplayName:      "DigitalOcean",
 		Description:      "A Pulumi package for creating and managing DigitalOcean cloud resources.",
 		Keywords:         []string{"pulumi", "digitalocean"},
 		License:          "Apache-2.0",


### PR DESCRIPTION
This PR is part of pulumi/registry#4672. The display name used was taken from `github.com/pulumi/registry/tools/resourcedocsgen/pkg/lookup.go`.