### PR TITLE
Skip flaky test

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -70,6 +70,7 @@ func TestAccFloatingIp(t *testing.T) {
 }
 
 func TestAccLoadbalancer(t *testing.T) {
+	t.Skip("Flaky test")
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "loadbalancer"),


### PR DESCRIPTION
The loadbalancer test is flaky and fails with "expected non-nil state with with nil error". As this provider does not have sufficient usage we will skip the test for now.

example: https://github.com/pulumi/pulumi-digitalocean/actions/runs/13044916594/job/36393950732?pr=951