### PR TITLE
Added correct DO urn mapping for ReservedIpv6 resource

### DIFF
--- a/provider/cmd/pulumi-resource-digitalocean/schema.json
+++ b/provider/cmd/pulumi-resource-digitalocean/schema.json
@@ -16393,7 +16393,7 @@
                     "type": "string",
                     "description": "The region that the reserved IPv6 needs to be reserved to.\n"
                 },
-                "urn": {
+                "reservedIpv6Urn": {
                     "type": "string",
                     "description": "the uniform resource name for the reserved ipv6\n"
                 }
@@ -16402,7 +16402,7 @@
                 "dropletId",
                 "ip",
                 "regionSlug",
-                "urn"
+                "reservedIpv6Urn"
             ],
             "inputProperties": {
                 "dropletId": {
@@ -16434,7 +16434,7 @@
                         "description": "The region that the reserved IPv6 needs to be reserved to.\n",
                         "willReplaceOnChanges": true
                     },
-                    "urn": {
+                    "reservedIpv6Urn": {
                         "type": "string",
                         "description": "the uniform resource name for the reserved ipv6\n"
                     }

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -303,7 +303,12 @@ func Provider() tfbridge.ProviderInfo {
 			},
 			"digitalocean_reserved_ip_assignment": {Tok: makeResource(digitalOceanMod, "ReservedIpAssignment")},
 
-			"digitalocean_reserved_ipv6":            {Docs: &info.Doc{AllowMissing: true}},
+			"digitalocean_reserved_ipv6": {
+				Docs: &info.Doc{AllowMissing: true},
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"urn": {Name: "reservedIpv6Urn"},
+				},
+			},
 			"digitalocean_reserved_ipv6_assignment": {Docs: &info.Doc{AllowMissing: true}},
 		},
 		ExtraTypes: map[string]schema.ComplexTypeSpec{

--- a/sdk/dotnet/ReservedIpv6.cs
+++ b/sdk/dotnet/ReservedIpv6.cs
@@ -61,8 +61,8 @@ namespace Pulumi.DigitalOcean
         /// <summary>
         /// the uniform resource name for the reserved ipv6
         /// </summary>
-        [Output("urn")]
-        public Output<string> Urn { get; private set; } = null!;
+        [Output("reservedIpv6Urn")]
+        public Output<string> ReservedIpv6Urn { get; private set; } = null!;
 
 
         /// <summary>
@@ -145,8 +145,8 @@ namespace Pulumi.DigitalOcean
         /// <summary>
         /// the uniform resource name for the reserved ipv6
         /// </summary>
-        [Input("urn")]
-        public Input<string>? Urn { get; set; }
+        [Input("reservedIpv6Urn")]
+        public Input<string>? ReservedIpv6Urn { get; set; }
 
         public ReservedIpv6State()
         {

--- a/sdk/go/digitalocean/reservedIpv6.go
+++ b/sdk/go/digitalocean/reservedIpv6.go
@@ -60,7 +60,7 @@ type ReservedIpv6 struct {
 	// The region that the reserved IPv6 needs to be reserved to.
 	RegionSlug pulumi.StringOutput `pulumi:"regionSlug"`
 	// the uniform resource name for the reserved ipv6
-	Urn pulumi.StringOutput `pulumi:"urn"`
+	ReservedIpv6Urn pulumi.StringOutput `pulumi:"reservedIpv6Urn"`
 }
 
 // NewReservedIpv6 registers a new resource with the given unique name, arguments, and options.
@@ -101,7 +101,7 @@ type reservedIpv6State struct {
 	// The region that the reserved IPv6 needs to be reserved to.
 	RegionSlug *string `pulumi:"regionSlug"`
 	// the uniform resource name for the reserved ipv6
-	Urn *string `pulumi:"urn"`
+	ReservedIpv6Urn *string `pulumi:"reservedIpv6Urn"`
 }
 
 type ReservedIpv6State struct {
@@ -110,7 +110,7 @@ type ReservedIpv6State struct {
 	// The region that the reserved IPv6 needs to be reserved to.
 	RegionSlug pulumi.StringPtrInput
 	// the uniform resource name for the reserved ipv6
-	Urn pulumi.StringPtrInput
+	ReservedIpv6Urn pulumi.StringPtrInput
 }
 
 func (ReservedIpv6State) ElementType() reflect.Type {
@@ -233,8 +233,8 @@ func (o ReservedIpv6Output) RegionSlug() pulumi.StringOutput {
 }
 
 // the uniform resource name for the reserved ipv6
-func (o ReservedIpv6Output) Urn() pulumi.StringOutput {
-	return o.ApplyT(func(v *ReservedIpv6) pulumi.StringOutput { return v.Urn }).(pulumi.StringOutput)
+func (o ReservedIpv6Output) ReservedIpv6Urn() pulumi.StringOutput {
+	return o.ApplyT(func(v *ReservedIpv6) pulumi.StringOutput { return v.ReservedIpv6Urn }).(pulumi.StringOutput)
 }
 
 type ReservedIpv6ArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/digitalocean/ReservedIpv6.java
+++ b/sdk/java/src/main/java/com/pulumi/digitalocean/ReservedIpv6.java
@@ -98,15 +98,15 @@ public class ReservedIpv6 extends com.pulumi.resources.CustomResource {
      * the uniform resource name for the reserved ipv6
      * 
      */
-    @Export(name="urn", refs={String.class}, tree="[0]")
-    private Output<String> urn;
+    @Export(name="reservedIpv6Urn", refs={String.class}, tree="[0]")
+    private Output<String> reservedIpv6Urn;
 
     /**
      * @return the uniform resource name for the reserved ipv6
      * 
      */
-    public Output<String> urn_() {
-        return this.urn;
+    public Output<String> reservedIpv6Urn() {
+        return this.reservedIpv6Urn;
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/digitalocean/inputs/ReservedIpv6State.java
+++ b/sdk/java/src/main/java/com/pulumi/digitalocean/inputs/ReservedIpv6State.java
@@ -49,15 +49,15 @@ public final class ReservedIpv6State extends com.pulumi.resources.ResourceArgs {
      * the uniform resource name for the reserved ipv6
      * 
      */
-    @Import(name="urn")
-    private @Nullable Output<String> urn;
+    @Import(name="reservedIpv6Urn")
+    private @Nullable Output<String> reservedIpv6Urn;
 
     /**
      * @return the uniform resource name for the reserved ipv6
      * 
      */
-    public Optional<Output<String>> urn() {
-        return Optional.ofNullable(this.urn);
+    public Optional<Output<String>> reservedIpv6Urn() {
+        return Optional.ofNullable(this.reservedIpv6Urn);
     }
 
     private ReservedIpv6State() {}
@@ -66,7 +66,7 @@ public final class ReservedIpv6State extends com.pulumi.resources.ResourceArgs {
         this.dropletId = $.dropletId;
         this.ip = $.ip;
         this.regionSlug = $.regionSlug;
-        this.urn = $.urn;
+        this.reservedIpv6Urn = $.reservedIpv6Urn;
     }
 
     public static Builder builder() {
@@ -127,24 +127,24 @@ public final class ReservedIpv6State extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param urn the uniform resource name for the reserved ipv6
+         * @param reservedIpv6Urn the uniform resource name for the reserved ipv6
          * 
          * @return builder
          * 
          */
-        public Builder urn(@Nullable Output<String> urn) {
-            $.urn = urn;
+        public Builder reservedIpv6Urn(@Nullable Output<String> reservedIpv6Urn) {
+            $.reservedIpv6Urn = reservedIpv6Urn;
             return this;
         }
 
         /**
-         * @param urn the uniform resource name for the reserved ipv6
+         * @param reservedIpv6Urn the uniform resource name for the reserved ipv6
          * 
          * @return builder
          * 
          */
-        public Builder urn(String urn) {
-            return urn(Output.of(urn));
+        public Builder reservedIpv6Urn(String reservedIpv6Urn) {
+            return reservedIpv6Urn(Output.of(reservedIpv6Urn));
         }
 
         public ReservedIpv6State build() {

--- a/sdk/nodejs/reservedIpv6.ts
+++ b/sdk/nodejs/reservedIpv6.ts
@@ -66,7 +66,7 @@ export class ReservedIpv6 extends pulumi.CustomResource {
     /**
      * the uniform resource name for the reserved ipv6
      */
-    public /*out*/ readonly urn!: pulumi.Output<string>;
+    public /*out*/ readonly reservedIpv6Urn!: pulumi.Output<string>;
 
     /**
      * Create a ReservedIpv6 resource with the given unique name, arguments, and options.
@@ -84,7 +84,7 @@ export class ReservedIpv6 extends pulumi.CustomResource {
             resourceInputs["dropletId"] = state ? state.dropletId : undefined;
             resourceInputs["ip"] = state ? state.ip : undefined;
             resourceInputs["regionSlug"] = state ? state.regionSlug : undefined;
-            resourceInputs["urn"] = state ? state.urn : undefined;
+            resourceInputs["reservedIpv6Urn"] = state ? state.reservedIpv6Urn : undefined;
         } else {
             const args = argsOrState as ReservedIpv6Args | undefined;
             if ((!args || args.regionSlug === undefined) && !opts.urn) {
@@ -93,7 +93,7 @@ export class ReservedIpv6 extends pulumi.CustomResource {
             resourceInputs["dropletId"] = args ? args.dropletId : undefined;
             resourceInputs["ip"] = args ? args.ip : undefined;
             resourceInputs["regionSlug"] = args ? args.regionSlug : undefined;
-            resourceInputs["urn"] = undefined /*out*/;
+            resourceInputs["reservedIpv6Urn"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(ReservedIpv6.__pulumiType, name, resourceInputs, opts);
@@ -113,7 +113,7 @@ export interface ReservedIpv6State {
     /**
      * the uniform resource name for the reserved ipv6
      */
-    urn?: pulumi.Input<string>;
+    reservedIpv6Urn?: pulumi.Input<string>;
 }
 
 /**

--- a/sdk/python/pulumi_digitalocean/reserved_ipv6.py
+++ b/sdk/python/pulumi_digitalocean/reserved_ipv6.py
@@ -70,11 +70,11 @@ class _ReservedIpv6State:
                  droplet_id: Optional[pulumi.Input[builtins.int]] = None,
                  ip: Optional[pulumi.Input[builtins.str]] = None,
                  region_slug: Optional[pulumi.Input[builtins.str]] = None,
-                 urn: Optional[pulumi.Input[builtins.str]] = None):
+                 reserved_ipv6_urn: Optional[pulumi.Input[builtins.str]] = None):
         """
         Input properties used for looking up and filtering ReservedIpv6 resources.
         :param pulumi.Input[builtins.str] region_slug: The region that the reserved IPv6 needs to be reserved to.
-        :param pulumi.Input[builtins.str] urn: the uniform resource name for the reserved ipv6
+        :param pulumi.Input[builtins.str] reserved_ipv6_urn: the uniform resource name for the reserved ipv6
         """
         if droplet_id is not None:
             pulumi.set(__self__, "droplet_id", droplet_id)
@@ -82,8 +82,8 @@ class _ReservedIpv6State:
             pulumi.set(__self__, "ip", ip)
         if region_slug is not None:
             pulumi.set(__self__, "region_slug", region_slug)
-        if urn is not None:
-            pulumi.set(__self__, "urn", urn)
+        if reserved_ipv6_urn is not None:
+            pulumi.set(__self__, "reserved_ipv6_urn", reserved_ipv6_urn)
 
     @property
     @pulumi.getter(name="dropletId")
@@ -116,16 +116,16 @@ class _ReservedIpv6State:
         pulumi.set(self, "region_slug", value)
 
     @property
-    @pulumi.getter
-    def urn(self) -> Optional[pulumi.Input[builtins.str]]:
+    @pulumi.getter(name="reservedIpv6Urn")
+    def reserved_ipv6_urn(self) -> Optional[pulumi.Input[builtins.str]]:
         """
         the uniform resource name for the reserved ipv6
         """
-        return pulumi.get(self, "urn")
+        return pulumi.get(self, "reserved_ipv6_urn")
 
-    @urn.setter
-    def urn(self, value: Optional[pulumi.Input[builtins.str]]):
-        pulumi.set(self, "urn", value)
+    @reserved_ipv6_urn.setter
+    def reserved_ipv6_urn(self, value: Optional[pulumi.Input[builtins.str]]):
+        pulumi.set(self, "reserved_ipv6_urn", value)
 
 
 @pulumi.type_token("digitalocean:index/reservedIpv6:ReservedIpv6")
@@ -230,7 +230,7 @@ class ReservedIpv6(pulumi.CustomResource):
             if region_slug is None and not opts.urn:
                 raise TypeError("Missing required property 'region_slug'")
             __props__.__dict__["region_slug"] = region_slug
-            __props__.__dict__["urn"] = None
+            __props__.__dict__["reserved_ipv6_urn"] = None
         super(ReservedIpv6, __self__).__init__(
             'digitalocean:index/reservedIpv6:ReservedIpv6',
             resource_name,
@@ -244,7 +244,7 @@ class ReservedIpv6(pulumi.CustomResource):
             droplet_id: Optional[pulumi.Input[builtins.int]] = None,
             ip: Optional[pulumi.Input[builtins.str]] = None,
             region_slug: Optional[pulumi.Input[builtins.str]] = None,
-            urn: Optional[pulumi.Input[builtins.str]] = None) -> 'ReservedIpv6':
+            reserved_ipv6_urn: Optional[pulumi.Input[builtins.str]] = None) -> 'ReservedIpv6':
         """
         Get an existing ReservedIpv6 resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -253,7 +253,7 @@ class ReservedIpv6(pulumi.CustomResource):
         :param pulumi.Input[str] id: The unique provider ID of the resource to lookup.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[builtins.str] region_slug: The region that the reserved IPv6 needs to be reserved to.
-        :param pulumi.Input[builtins.str] urn: the uniform resource name for the reserved ipv6
+        :param pulumi.Input[builtins.str] reserved_ipv6_urn: the uniform resource name for the reserved ipv6
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -262,7 +262,7 @@ class ReservedIpv6(pulumi.CustomResource):
         __props__.__dict__["droplet_id"] = droplet_id
         __props__.__dict__["ip"] = ip
         __props__.__dict__["region_slug"] = region_slug
-        __props__.__dict__["urn"] = urn
+        __props__.__dict__["reserved_ipv6_urn"] = reserved_ipv6_urn
         return ReservedIpv6(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -284,10 +284,10 @@ class ReservedIpv6(pulumi.CustomResource):
         return pulumi.get(self, "region_slug")
 
     @property
-    @pulumi.getter
-    def urn(self) -> pulumi.Output[builtins.str]:
+    @pulumi.getter(name="reservedIpv6Urn")
+    def reserved_ipv6_urn(self) -> pulumi.Output[builtins.str]:
         """
         the uniform resource name for the reserved ipv6
         """
-        return pulumi.get(self, "urn")
+        return pulumi.get(self, "reserved_ipv6_urn")
 


### PR DESCRIPTION
Detected another URN field crash when generating package for Scala SDK for Pulumi. Fixed according to the convention.